### PR TITLE
fix: correct shortest window date display and blocked date validation

### DIFF
--- a/components/TeamManagement.tsx
+++ b/components/TeamManagement.tsx
@@ -73,10 +73,22 @@ interface Employee {
 }
 
 // Safe date formatting helper to handle invalid dates
+// Handles date-only strings (YYYY-MM-DD) as local dates to avoid timezone shift
 const formatDateSafe = (dateStr: string | undefined | null): string => {
   if (!dateStr) return 'Invalid Date';
   try {
-    const date = new Date(dateStr);
+    let date: Date;
+
+    // Check if it's a date-only string (YYYY-MM-DD) without time component
+    // These should be parsed as local dates to avoid UTC interpretation shifting the day
+    if (/^\d{4}-\d{2}-\d{2}$/.test(dateStr)) {
+      const [year, month, day] = dateStr.split('-').map(Number);
+      date = new Date(year, month - 1, day); // month is 0-indexed
+    } else {
+      // Full ISO timestamp or other format - parse normally
+      date = new Date(dateStr);
+    }
+
     if (isNaN(date.getTime())) return 'Invalid Date';
     return date.toLocaleDateString();
   } catch {

--- a/components/project/ProjectBookingForm.tsx
+++ b/components/project/ProjectBookingForm.tsx
@@ -2004,6 +2004,17 @@ export default function ProjectBookingForm({
       const startUtc = parseISO(proposals.shortestThroughputProposal.start);
       const endUtc = parseISO(proposals.shortestThroughputProposal.executionEnd);
 
+      // Validate parsed dates to avoid NaN in calculations
+      if (Number.isNaN(startUtc.getTime()) || Number.isNaN(endUtc.getTime())) {
+        console.warn('[shortestThroughputDetails] Invalid date parsed:', {
+          start: proposals.shortestThroughputProposal.start,
+          end: proposals.shortestThroughputProposal.executionEnd,
+          startValid: !Number.isNaN(startUtc.getTime()),
+          endValid: !Number.isNaN(endUtc.getTime()),
+        });
+        return { startDate: startUtc, endDate: endUtc, totalDays: 1 };
+      }
+
       // Use toZonedTime ONLY for calendar day calculations (not for display)
       // This ensures differenceInCalendarDays counts days in the professional's timezone
       const startZoned = toZonedTime(startUtc, tz);
@@ -2015,7 +2026,8 @@ export default function ProjectBookingForm({
       );
       // Return UTC dates - formatInTimeZone will convert them correctly for display
       return { startDate: startUtc, endDate: endUtc, totalDays };
-    } catch {
+    } catch (error) {
+      console.error('[shortestThroughputDetails] Error processing dates:', error);
       return null;
     }
   })();


### PR DESCRIPTION
  - Schedule Engine: Add blockedDates check in multi-resource mode to prevent company-blocked dates from being valid start dates. This aligns with calendar availability logic.

  - ProjectBookingForm: Fix timezone double-conversion bug causing "Shortest Consecutive Window" to show UTC dates instead of professional's timezone. Keep dates as UTC and let formatInTimeZone handle the single conversion for display.

  Fixes:
  - Shortest window showing Feb 16 (UTC) instead of Feb 17 (Europe/Brussels)
  - Schedule proposals returning blocked dates as valid start dates

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation and filtering of blocked booking date ranges so only valid ranges are shown.
  * Added a warning banner indicating how many invalid booking ranges are hidden.
  * Corrected pagination and counts to reflect filtered valid ranges.

* **Improvements**
  * Safer date parsing and formatting to avoid invalid dates and timezone-related shifts in displays.
  * Retained UTC for internal calculations while keeping local/timezone-accurate display formatting.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->