### PR TITLE
feat: format scheduled dates in Booking Payment page to display in professional's timezone

### DIFF
--- a/app/bookings/[id]/payment/page.tsx
+++ b/app/bookings/[id]/payment/page.tsx
@@ -1205,7 +1205,7 @@ export default function BookingPaymentPage() {
                     <div className="text-xs space-y-1">
                       <p>
                         <span className="font-medium">Start:</span>{' '}
-                        {scheduleWindow.scheduledStartDate.slice(0, 10)}
+                        {formatInTimeZone(parseISO(scheduleWindow.scheduledStartDate), professionalTimezone, 'yyyy-MM-dd')}
                         {scheduleWindow.scheduledStartTime ? ` at ${scheduleWindow.scheduledStartTime}` : ''}
                       </p>
                       {(() => {
@@ -1219,12 +1219,12 @@ export default function BookingPaymentPage() {
                       })()}
                       <p>
                         <span className="font-medium">Execution ends:</span>{' '}
-                        {scheduleWindow.scheduledExecutionEndDate.slice(0, 10)}
+                        {formatInTimeZone(parseISO(scheduleWindow.scheduledExecutionEndDate), professionalTimezone, 'yyyy-MM-dd')}
                       </p>
                       {scheduleWindow.scheduledBufferEndDate && (
                         <p>
                           <span className="font-medium">Project completion (incl. buffer):</span>{' '}
-                          {scheduleWindow.scheduledBufferEndDate.slice(0, 10)}
+                          {formatInTimeZone(parseISO(scheduleWindow.scheduledBufferEndDate), professionalTimezone, 'yyyy-MM-dd')}
                         </p>
                       )}
                     </div>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Bug Fixes**
- Fixed date display formatting in payment booking pages to properly account for timezone when displaying scheduled dates, execution end dates, and buffer periods
- Improved overall accuracy of booking payment summaries by converting and formatting dates according to the appropriate professional timezone settings instead of using simple string parsing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->