### PR TITLE
feat: add admin support and social settings pages

### DIFF
--- a/app/(pages)/about/page.tsx
+++ b/app/(pages)/about/page.tsx
@@ -13,6 +13,8 @@ export const dynamic = "force-dynamic";
 
 async function fetchAboutContent() {
   try {
+    const landing = await publicGetCms("landing", "about");
+    if (landing) return landing;
     return await publicGetCms("policy", "about");
   } catch {
     return null;

--- a/app/(pages)/about/page.tsx
+++ b/app/(pages)/about/page.tsx
@@ -13,9 +13,9 @@ export const dynamic = "force-dynamic";
 
 async function fetchAboutContent() {
   try {
-    const landing = await publicGetCms("landing", "about");
-    if (landing) return landing;
-    return await publicGetCms("policy", "about");
+    const policy = await publicGetCms("policy", "about");
+    if (policy) return policy;
+    return await publicGetCms("landing", "about");
   } catch {
     return null;
   }

--- a/app/(pages)/admin/cms/page.tsx
+++ b/app/(pages)/admin/cms/page.tsx
@@ -11,9 +11,11 @@ import {
   CmsContentType,
   CMS_TYPE_LABELS,
   CMS_TYPE_ORDER,
+  getPublicPathForCms,
+  getLandingServicePath,
 } from "@/lib/cms";
 import { cn } from "@/lib/utils";
-import { AlertCircle, FileText, Loader2, Plus, Search, Sparkles } from "lucide-react";
+import { AlertCircle, FileText, Loader2, Plus, Search, Share2, Sparkles } from "lucide-react";
 import { toast } from "sonner";
 
 const STATUS_FILTERS: Array<{ value: CmsContentStatus | "all"; label: string }> = [
@@ -169,6 +171,12 @@ export default function CmsAdminListPage() {
               </span>
             </button>
           ))}
+          <Link
+            href="/admin/cms/social"
+            className="inline-flex items-center gap-2 rounded-xl border border-pink-200 bg-white/60 px-4 py-2 text-sm font-medium text-rose-700 transition hover:bg-rose-50 hover:shadow-sm"
+          >
+            <Share2 size={14} /> Social Media
+          </Link>
         </div>
 
         {/* Filters */}
@@ -238,6 +246,8 @@ export default function CmsAdminListPage() {
 }
 
 function ContentRow({ item }: { item: CmsContent }) {
+  const primaryPath = getPublicPathForCms(item.type, item.slug);
+  const landingServicePath = item.type === "landing" ? getLandingServicePath(item.slug) : null;
   return (
     <Link
       href={`/admin/cms/${item._id}/edit`}
@@ -267,6 +277,19 @@ function ContentRow({ item }: { item: CmsContent }) {
               </>
             ) : null}
           </div>
+          {primaryPath && (
+            <div className="mt-1 flex flex-wrap items-center gap-1 text-[11px] text-rose-400">
+              <span>Displayed at</span>
+              <code className="rounded bg-rose-50 px-1.5 py-0.5 text-rose-600">{primaryPath}</code>
+              {landingServicePath && (
+                <>
+                  <span>or</span>
+                  <code className="rounded bg-rose-50 px-1.5 py-0.5 text-rose-600">{landingServicePath}</code>
+                  <span>(if a matching service exists)</span>
+                </>
+              )}
+            </div>
+          )}
         </div>
       </div>
     </Link>

--- a/app/(pages)/admin/cms/social/page.tsx
+++ b/app/(pages)/admin/cms/social/page.tsx
@@ -1,0 +1,117 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { toast } from "sonner";
+import { ArrowLeft, Loader2, Save, Share2 } from "lucide-react";
+import { useAuth } from "@/contexts/AuthContext";
+import { adminGetSiteSettings, adminUpdateSiteSettings, SocialLinks } from "@/lib/siteSettings";
+
+const FIELDS: Array<{ key: keyof SocialLinks; label: string; placeholder: string }> = [
+  { key: "facebook", label: "Facebook", placeholder: "https://facebook.com/fixera" },
+  { key: "twitter", label: "Twitter / X", placeholder: "https://twitter.com/fixera" },
+  { key: "instagram", label: "Instagram", placeholder: "https://instagram.com/fixera" },
+  { key: "linkedin", label: "LinkedIn", placeholder: "https://linkedin.com/company/fixera" },
+  { key: "tiktok", label: "TikTok", placeholder: "https://tiktok.com/@fixera" },
+  { key: "youtube", label: "YouTube", placeholder: "https://youtube.com/@fixera" },
+];
+
+export default function AdminSocialSettingsPage() {
+  const { user, isAuthenticated, loading } = useAuth();
+  const router = useRouter();
+  const [values, setValues] = useState<SocialLinks>({});
+  const [fetching, setFetching] = useState(true);
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    if (loading) return;
+    if (!isAuthenticated || user?.role !== "admin") {
+      router.replace("/login");
+    }
+  }, [user, isAuthenticated, loading, router]);
+
+  useEffect(() => {
+    if (!isAuthenticated || user?.role !== "admin") return;
+    setFetching(true);
+    adminGetSiteSettings()
+      .then((s) => setValues(s.socialLinks || {}))
+      .catch((err) => toast.error(err instanceof Error ? err.message : "Failed to load settings"))
+      .finally(() => setFetching(false));
+  }, [isAuthenticated, user]);
+
+  const save = async () => {
+    setSaving(true);
+    try {
+      const next = await adminUpdateSiteSettings({ socialLinks: values });
+      setValues(next.socialLinks || {});
+      toast.success("Social links saved");
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Save failed");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  if (loading || fetching) {
+    return (
+      <div className="flex min-h-[60vh] items-center justify-center bg-gradient-to-br from-rose-50 via-pink-50 to-white">
+        <Loader2 className="animate-spin text-rose-500" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-rose-50 via-pink-50 to-white pt-16 pb-16">
+      <div className="sticky top-16 z-20 border-b border-pink-100 bg-white/80 backdrop-blur">
+        <div className="mx-auto flex max-w-4xl items-center justify-between px-6 py-4">
+          <Link
+            href="/admin/cms"
+            className="inline-flex items-center gap-2 rounded-xl px-3 py-2 text-sm text-rose-700 transition hover:bg-rose-50"
+          >
+            <ArrowLeft size={16} /> Back to content
+          </Link>
+          <button
+            onClick={save}
+            disabled={saving}
+            className="inline-flex items-center gap-2 rounded-xl bg-gradient-to-r from-rose-500 via-pink-500 to-orange-400 px-5 py-2 text-sm font-semibold text-white shadow-md shadow-rose-200 transition hover:shadow-lg hover:shadow-rose-300 disabled:opacity-50"
+          >
+            {saving ? <Loader2 className="animate-spin" size={14} /> : <Save size={14} />} Save
+          </button>
+        </div>
+      </div>
+
+      <div className="mx-auto max-w-4xl px-6 pt-6">
+        <div className="rounded-2xl bg-gradient-to-br from-rose-100 via-pink-100 to-orange-100 p-[1.5px] shadow-sm">
+          <div className="rounded-[calc(1rem-1.5px)] bg-white">
+            <div className="space-y-5 p-6">
+              <div className="flex items-center gap-3">
+                <div className="inline-flex h-10 w-10 items-center justify-center rounded-xl bg-gradient-to-br from-rose-400 to-pink-500 text-white shadow-md shadow-rose-200">
+                  <Share2 size={18} />
+                </div>
+                <div>
+                  <h1 className="text-lg font-semibold text-rose-900">Social Media</h1>
+                  <p className="text-xs text-rose-500">Paste full URLs. Icons hide automatically when a link is empty.</p>
+                </div>
+              </div>
+
+              <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+                {FIELDS.map((f) => (
+                  <div key={f.key} className="space-y-1.5">
+                    <label className="text-xs font-semibold uppercase tracking-wide text-rose-700">{f.label}</label>
+                    <input
+                      value={values[f.key] || ""}
+                      onChange={(e) => setValues((v) => ({ ...v, [f.key]: e.target.value }))}
+                      placeholder={f.placeholder}
+                      className="w-full rounded-xl border border-pink-200 bg-white/60 px-4 py-2 text-sm outline-none transition focus:border-rose-400 focus:bg-white focus:ring-2 focus:ring-rose-200"
+                    />
+                  </div>
+                ))}
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/(pages)/admin/cms/social/page.tsx
+++ b/app/(pages)/admin/cms/social/page.tsx
@@ -17,6 +17,16 @@ const FIELDS: Array<{ key: keyof SocialLinks; label: string; placeholder: string
   { key: "youtube", label: "YouTube", placeholder: "https://youtube.com/@fixera" },
 ];
 
+function isValidUrl(v: string): boolean {
+  if (!v.trim()) return true;
+  try {
+    const parsed = new URL(v.trim());
+    return parsed.protocol === "http:" || parsed.protocol === "https:";
+  } catch {
+    return false;
+  }
+}
+
 export default function AdminSocialSettingsPage() {
   const { user, isAuthenticated, loading } = useAuth();
   const router = useRouter();
@@ -35,12 +45,29 @@ export default function AdminSocialSettingsPage() {
     if (!isAuthenticated || user?.role !== "admin") return;
     setFetching(true);
     adminGetSiteSettings()
-      .then((s) => setValues(s.socialLinks || {}))
+      .then((s) => {
+        const loaded = s.socialLinks || {};
+        setValues(loaded);
+        const invalid = (Object.entries(loaded) as Array<[keyof SocialLinks, string | undefined]>)
+          .filter(([, v]) => v && !isValidUrl(v))
+          .map(([k]) => k);
+        if (invalid.length > 0) {
+          toast.error(`Stored link looks malformed: ${invalid.join(", ")}`);
+        }
+      })
       .catch((err) => toast.error(err instanceof Error ? err.message : "Failed to load settings"))
       .finally(() => setFetching(false));
   }, [isAuthenticated, user]);
 
+  const fieldErrors = (Object.entries(values) as Array<[keyof SocialLinks, string | undefined]>)
+    .filter(([, v]) => v && !isValidUrl(v))
+    .map(([k]) => k);
+
   const save = async () => {
+    if (fieldErrors.length > 0) {
+      toast.error(`Fix invalid URL(s): ${fieldErrors.join(", ")}`);
+      return;
+    }
     setSaving(true);
     try {
       const next = await adminUpdateSiteSettings({ socialLinks: values });
@@ -73,8 +100,8 @@ export default function AdminSocialSettingsPage() {
           </Link>
           <button
             onClick={save}
-            disabled={saving}
-            className="inline-flex items-center gap-2 rounded-xl bg-gradient-to-r from-rose-500 via-pink-500 to-orange-400 px-5 py-2 text-sm font-semibold text-white shadow-md shadow-rose-200 transition hover:shadow-lg hover:shadow-rose-300 disabled:opacity-50"
+            disabled={saving || fieldErrors.length > 0}
+            className="inline-flex items-center gap-2 rounded-xl bg-gradient-to-r from-rose-500 via-pink-500 to-orange-400 px-5 py-2 text-sm font-semibold text-white shadow-md shadow-rose-200 transition hover:shadow-lg hover:shadow-rose-300 disabled:opacity-50 disabled:cursor-not-allowed"
           >
             {saving ? <Loader2 className="animate-spin" size={14} /> : <Save size={14} />} Save
           </button>
@@ -96,17 +123,29 @@ export default function AdminSocialSettingsPage() {
               </div>
 
               <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
-                {FIELDS.map((f) => (
-                  <div key={f.key} className="space-y-1.5">
-                    <label className="text-xs font-semibold uppercase tracking-wide text-rose-700">{f.label}</label>
-                    <input
-                      value={values[f.key] || ""}
-                      onChange={(e) => setValues((v) => ({ ...v, [f.key]: e.target.value }))}
-                      placeholder={f.placeholder}
-                      className="w-full rounded-xl border border-pink-200 bg-white/60 px-4 py-2 text-sm outline-none transition focus:border-rose-400 focus:bg-white focus:ring-2 focus:ring-rose-200"
-                    />
-                  </div>
-                ))}
+                {FIELDS.map((f) => {
+                  const raw = values[f.key] || "";
+                  const invalid = Boolean(raw) && !isValidUrl(raw);
+                  return (
+                    <div key={f.key} className="space-y-1.5">
+                      <label className="text-xs font-semibold uppercase tracking-wide text-rose-700">{f.label}</label>
+                      <input
+                        value={raw}
+                        onChange={(e) => setValues((v) => ({ ...v, [f.key]: e.target.value }))}
+                        placeholder={f.placeholder}
+                        aria-invalid={invalid || undefined}
+                        className={
+                          invalid
+                            ? "w-full rounded-xl border border-rose-400 bg-rose-50/60 px-4 py-2 text-sm outline-none transition focus:border-rose-500 focus:bg-white focus:ring-2 focus:ring-rose-300"
+                            : "w-full rounded-xl border border-pink-200 bg-white/60 px-4 py-2 text-sm outline-none transition focus:border-rose-400 focus:bg-white focus:ring-2 focus:ring-rose-200"
+                        }
+                      />
+                      {invalid && (
+                        <p className="text-[11px] text-rose-600">Use a full URL starting with http:// or https://</p>
+                      )}
+                    </div>
+                  );
+                })}
               </div>
             </div>
           </div>

--- a/app/(pages)/admin/support/page.tsx
+++ b/app/(pages)/admin/support/page.tsx
@@ -50,8 +50,12 @@ export default function AdminSupportPage() {
         <h1 className="text-3xl font-bold text-indigo-900">Support — Admin</h1>
         <p className="mt-1 text-sm text-indigo-600/80">Tickets and meeting requests from professionals.</p>
 
-        <div className="mt-6 flex gap-2">
+        <div role="tablist" aria-label="Support sections" className="mt-6 flex gap-2">
           <button
+            id="tickets-tab"
+            role="tab"
+            aria-selected={tab === "tickets"}
+            aria-controls="tickets-panel"
             onClick={() => setTab("tickets")}
             className={cn(
               "inline-flex items-center gap-2 rounded-xl border px-4 py-2 text-sm font-medium transition",
@@ -63,6 +67,10 @@ export default function AdminSupportPage() {
             <LifeBuoy size={14} /> Tickets
           </button>
           <button
+            id="meetings-tab"
+            role="tab"
+            aria-selected={tab === "meetings"}
+            aria-controls="meetings-panel"
             onClick={() => setTab("meetings")}
             className={cn(
               "inline-flex items-center gap-2 rounded-xl border px-4 py-2 text-sm font-medium transition",
@@ -75,7 +83,15 @@ export default function AdminSupportPage() {
           </button>
         </div>
 
-        <div className="mt-6">{tab === "tickets" ? <TicketsAdmin /> : <MeetingsAdmin />}</div>
+        {tab === "tickets" ? (
+          <div role="tabpanel" id="tickets-panel" aria-labelledby="tickets-tab" className="mt-6">
+            <TicketsAdmin />
+          </div>
+        ) : (
+          <div role="tabpanel" id="meetings-panel" aria-labelledby="meetings-tab" className="mt-6">
+            <MeetingsAdmin />
+          </div>
+        )}
       </div>
     </div>
   );
@@ -295,8 +311,7 @@ function MeetingsAdmin() {
                       scheduledAt: draft.scheduledAt ? new Date(draft.scheduledAt).toISOString() : undefined,
                       adminResponse: draft.adminResponse,
                     };
-                    // If admin has set a time but status is still pending, auto-advance to scheduled
-                    if (draft.scheduledAt && m.status === "pending") {
+                    if (draft.scheduledAt) {
                       payload.status = "scheduled";
                     }
                     update(m._id, payload);

--- a/app/(pages)/admin/support/page.tsx
+++ b/app/(pages)/admin/support/page.tsx
@@ -1,0 +1,259 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { toast } from "sonner";
+import { Loader2, LifeBuoy, CalendarClock } from "lucide-react";
+import { useAuth } from "@/contexts/AuthContext";
+import { cn } from "@/lib/utils";
+import {
+  adminListTickets,
+  adminUpdateTicket,
+  adminListMeetingRequests,
+  adminUpdateMeetingRequest,
+  SupportTicket,
+  MeetingRequest,
+  SupportTicketStatus,
+  MeetingRequestStatus,
+} from "@/lib/support";
+
+const TICKET_STATUSES: SupportTicketStatus[] = ["open", "in_progress", "resolved", "closed"];
+const MEETING_STATUSES: MeetingRequestStatus[] = ["pending", "scheduled", "declined", "cancelled"];
+
+type Tab = "tickets" | "meetings";
+
+export default function AdminSupportPage() {
+  const { user, isAuthenticated, loading } = useAuth();
+  const router = useRouter();
+  const [tab, setTab] = useState<Tab>("tickets");
+
+  useEffect(() => {
+    if (loading) return;
+    if (!isAuthenticated || user?.role !== "admin") router.replace("/login");
+  }, [user, isAuthenticated, loading, router]);
+
+  if (loading || !isAuthenticated || user?.role !== "admin") {
+    return (
+      <div className="flex min-h-[60vh] items-center justify-center bg-gradient-to-br from-indigo-50 via-blue-50 to-white">
+        <Loader2 className="animate-spin text-indigo-500" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-indigo-50 via-blue-50 to-white pb-16 pt-24">
+      <div className="mx-auto max-w-6xl px-6">
+        <h1 className="text-3xl font-bold text-indigo-900">Professional Support</h1>
+        <p className="mt-1 text-sm text-indigo-600/80">Tickets and meeting requests from professionals.</p>
+
+        <div className="mt-6 flex gap-2">
+          <button
+            onClick={() => setTab("tickets")}
+            className={cn(
+              "inline-flex items-center gap-2 rounded-xl border px-4 py-2 text-sm font-medium transition",
+              tab === "tickets"
+                ? "border-transparent bg-gradient-to-r from-indigo-500 to-blue-500 text-white shadow-md shadow-indigo-200"
+                : "border-indigo-200 bg-white/60 text-indigo-700 hover:bg-indigo-50"
+            )}
+          >
+            <LifeBuoy size={14} /> Tickets
+          </button>
+          <button
+            onClick={() => setTab("meetings")}
+            className={cn(
+              "inline-flex items-center gap-2 rounded-xl border px-4 py-2 text-sm font-medium transition",
+              tab === "meetings"
+                ? "border-transparent bg-gradient-to-r from-indigo-500 to-blue-500 text-white shadow-md shadow-indigo-200"
+                : "border-indigo-200 bg-white/60 text-indigo-700 hover:bg-indigo-50"
+            )}
+          >
+            <CalendarClock size={14} /> Meeting requests
+          </button>
+        </div>
+
+        <div className="mt-6">{tab === "tickets" ? <TicketsAdmin /> : <MeetingsAdmin />}</div>
+      </div>
+    </div>
+  );
+}
+
+function TicketsAdmin() {
+  const [items, setItems] = useState<SupportTicket[] | null>(null);
+  const [reply, setReply] = useState<Record<string, string>>({});
+
+  const load = () =>
+    adminListTickets()
+      .then(setItems)
+      .catch((e) => toast.error(e instanceof Error ? e.message : "Failed to load tickets"));
+
+  useEffect(() => {
+    load();
+  }, []);
+
+  const update = async (id: string, payload: { status?: SupportTicketStatus; reply?: string }) => {
+    try {
+      await adminUpdateTicket(id, payload);
+      setReply((r) => ({ ...r, [id]: "" }));
+      toast.success("Updated");
+      load();
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : "Update failed");
+    }
+  };
+
+  if (items === null) return <div className="flex justify-center py-10"><Loader2 className="animate-spin text-indigo-500" /></div>;
+  if (items.length === 0) return <div className="rounded-2xl border border-dashed border-indigo-300 bg-white py-10 text-center text-sm text-indigo-500">No tickets.</div>;
+
+  return (
+    <div className="space-y-3">
+      {items.map((t) => {
+        const u = typeof t.userId === "object" ? t.userId : null;
+        return (
+          <div key={t._id} className="rounded-2xl bg-gradient-to-br from-indigo-100 via-blue-100 to-cyan-100 p-[1.5px]">
+            <div className="rounded-[calc(1rem-1.5px)] bg-white p-5">
+              <div className="flex items-center justify-between gap-3">
+                <div>
+                  <h3 className="font-semibold text-indigo-900">{t.subject}</h3>
+                  <p className="text-xs text-indigo-500">
+                    {u?.name || "Unknown"} {u?.email ? `· ${u.email}` : ""} · {new Date(t.createdAt).toLocaleString()}
+                  </p>
+                </div>
+                <select
+                  value={t.status}
+                  onChange={(e) => update(t._id, { status: e.target.value as SupportTicketStatus })}
+                  className="rounded-xl border border-indigo-200 bg-white px-3 py-1.5 text-xs outline-none focus:border-indigo-400 focus:ring-2 focus:ring-indigo-200"
+                >
+                  {TICKET_STATUSES.map((s) => (
+                    <option key={s} value={s}>{s.replace("_", " ")}</option>
+                  ))}
+                </select>
+              </div>
+              <p className="mt-2 whitespace-pre-wrap text-sm text-indigo-800/80">{t.description}</p>
+              {t.replies.length > 0 && (
+                <div className="mt-3 space-y-1.5 border-l-2 border-indigo-200 pl-3">
+                  {t.replies.map((r, idx) => (
+                    <div key={idx} className="text-xs">
+                      <span className={cn("font-semibold", r.authorRole === "admin" ? "text-blue-700" : "text-indigo-700")}>
+                        {r.authorRole === "admin" ? "Admin" : "Professional"}
+                      </span>
+                      <span className="text-indigo-400"> · {new Date(r.createdAt).toLocaleString()}</span>
+                      <div className="whitespace-pre-wrap text-indigo-800/90">{r.body}</div>
+                    </div>
+                  ))}
+                </div>
+              )}
+              <div className="mt-3 flex items-center gap-2">
+                <input
+                  value={reply[t._id] || ""}
+                  onChange={(e) => setReply((r) => ({ ...r, [t._id]: e.target.value }))}
+                  placeholder="Reply to the professional…"
+                  className="flex-1 rounded-xl border border-indigo-200 bg-white/60 px-3 py-1.5 text-sm outline-none focus:border-indigo-400 focus:bg-white focus:ring-2 focus:ring-indigo-200"
+                />
+                <button
+                  onClick={() => reply[t._id]?.trim() && update(t._id, { reply: reply[t._id].trim() })}
+                  className="rounded-xl bg-indigo-500 px-3 py-1.5 text-sm font-medium text-white hover:bg-indigo-600"
+                >
+                  Send
+                </button>
+              </div>
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+function MeetingsAdmin() {
+  const [items, setItems] = useState<MeetingRequest[] | null>(null);
+  const [drafts, setDrafts] = useState<Record<string, { scheduledAt: string; adminResponse: string }>>({});
+
+  const load = () =>
+    adminListMeetingRequests()
+      .then(setItems)
+      .catch((e) => toast.error(e instanceof Error ? e.message : "Failed to load"));
+
+  useEffect(() => {
+    load();
+  }, []);
+
+  const update = async (id: string, payload: Parameters<typeof adminUpdateMeetingRequest>[1]) => {
+    try {
+      await adminUpdateMeetingRequest(id, payload);
+      toast.success("Updated");
+      load();
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : "Update failed");
+    }
+  };
+
+  if (items === null) return <div className="flex justify-center py-10"><Loader2 className="animate-spin text-indigo-500" /></div>;
+  if (items.length === 0) return <div className="rounded-2xl border border-dashed border-indigo-300 bg-white py-10 text-center text-sm text-indigo-500">No meeting requests.</div>;
+
+  return (
+    <div className="space-y-3">
+      {items.map((m) => {
+        const u = typeof m.userId === "object" ? m.userId : null;
+        const draft = drafts[m._id] || { scheduledAt: m.scheduledAt ? new Date(m.scheduledAt).toISOString().slice(0, 16) : "", adminResponse: m.adminResponse || "" };
+        return (
+          <div key={m._id} className="rounded-2xl bg-gradient-to-br from-indigo-100 via-blue-100 to-cyan-100 p-[1.5px]">
+            <div className="rounded-[calc(1rem-1.5px)] bg-white p-5 space-y-2">
+              <div className="flex items-center justify-between gap-3">
+                <div>
+                  <h3 className="font-semibold text-indigo-900">{m.topic}</h3>
+                  <p className="text-xs text-indigo-500">
+                    {u?.name || "Unknown"} {u?.email ? `· ${u.email}` : ""} · {new Date(m.createdAt).toLocaleString()}
+                  </p>
+                </div>
+                <select
+                  value={m.status}
+                  onChange={(e) => update(m._id, { status: e.target.value as MeetingRequestStatus })}
+                  className="rounded-xl border border-indigo-200 bg-white px-3 py-1.5 text-xs outline-none focus:border-indigo-400 focus:ring-2 focus:ring-indigo-200"
+                >
+                  {MEETING_STATUSES.map((s) => (
+                    <option key={s} value={s}>{s}</option>
+                  ))}
+                </select>
+              </div>
+              <p className="text-sm text-indigo-700/80"><span className="font-medium">Preferred:</span> {m.preferredTimes}</p>
+              <p className="text-xs text-indigo-500">Duration: {m.durationMinutes} min</p>
+              <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+                <label className="text-xs text-indigo-700">
+                  Scheduled at
+                  <input
+                    type="datetime-local"
+                    value={draft.scheduledAt}
+                    onChange={(e) => setDrafts((d) => ({ ...d, [m._id]: { ...draft, scheduledAt: e.target.value } }))}
+                    className="mt-1 w-full rounded-xl border border-indigo-200 bg-white/60 px-3 py-1.5 text-sm outline-none focus:border-indigo-400 focus:bg-white focus:ring-2 focus:ring-indigo-200"
+                  />
+                </label>
+                <label className="text-xs text-indigo-700">
+                  Response
+                  <input
+                    value={draft.adminResponse}
+                    onChange={(e) => setDrafts((d) => ({ ...d, [m._id]: { ...draft, adminResponse: e.target.value } }))}
+                    placeholder="Optional note"
+                    className="mt-1 w-full rounded-xl border border-indigo-200 bg-white/60 px-3 py-1.5 text-sm outline-none focus:border-indigo-400 focus:bg-white focus:ring-2 focus:ring-indigo-200"
+                  />
+                </label>
+              </div>
+              <div className="flex justify-end">
+                <button
+                  onClick={() =>
+                    update(m._id, {
+                      scheduledAt: draft.scheduledAt ? new Date(draft.scheduledAt).toISOString() : undefined,
+                      adminResponse: draft.adminResponse,
+                    })
+                  }
+                  className="inline-flex items-center gap-2 rounded-xl bg-indigo-500 px-4 py-1.5 text-sm font-medium text-white hover:bg-indigo-600"
+                >
+                  Save
+                </button>
+              </div>
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/app/(pages)/admin/support/page.tsx
+++ b/app/(pages)/admin/support/page.tsx
@@ -80,6 +80,7 @@ export default function AdminSupportPage() {
 function TicketsAdmin() {
   const [items, setItems] = useState<SupportTicket[] | null>(null);
   const [reply, setReply] = useState<Record<string, string>>({});
+  const [saving, setSaving] = useState<Record<string, boolean>>({});
 
   const load = () =>
     adminListTickets()
@@ -91,13 +92,19 @@ function TicketsAdmin() {
   }, []);
 
   const update = async (id: string, payload: { status?: SupportTicketStatus; reply?: string }) => {
+    if (saving[id]) return;
+    setSaving((s) => ({ ...s, [id]: true }));
     try {
       await adminUpdateTicket(id, payload);
-      setReply((r) => ({ ...r, [id]: "" }));
+      if (payload.reply && payload.reply.trim()) {
+        setReply((r) => ({ ...r, [id]: "" }));
+      }
       toast.success("Updated");
       load();
     } catch (e) {
       toast.error(e instanceof Error ? e.message : "Update failed");
+    } finally {
+      setSaving((s) => ({ ...s, [id]: false }));
     }
   };
 
@@ -146,13 +153,16 @@ function TicketsAdmin() {
                 <input
                   value={reply[t._id] || ""}
                   onChange={(e) => setReply((r) => ({ ...r, [t._id]: e.target.value }))}
+                  disabled={Boolean(saving[t._id])}
                   placeholder="Reply to the professional…"
-                  className="flex-1 rounded-xl border border-indigo-200 bg-white/60 px-3 py-1.5 text-sm outline-none focus:border-indigo-400 focus:bg-white focus:ring-2 focus:ring-indigo-200"
+                  className="flex-1 rounded-xl border border-indigo-200 bg-white/60 px-3 py-1.5 text-sm outline-none focus:border-indigo-400 focus:bg-white focus:ring-2 focus:ring-indigo-200 disabled:opacity-50"
                 />
                 <button
                   onClick={() => reply[t._id]?.trim() && update(t._id, { reply: reply[t._id].trim() })}
-                  className="rounded-xl bg-indigo-500 px-3 py-1.5 text-sm font-medium text-white hover:bg-indigo-600"
+                  disabled={Boolean(saving[t._id]) || !reply[t._id]?.trim()}
+                  className="inline-flex items-center gap-1 rounded-xl bg-indigo-500 px-3 py-1.5 text-sm font-medium text-white hover:bg-indigo-600 disabled:opacity-50 disabled:cursor-not-allowed"
                 >
+                  {saving[t._id] ? <Loader2 className="animate-spin" size={12} /> : null}
                   Send
                 </button>
               </div>
@@ -167,6 +177,7 @@ function TicketsAdmin() {
 function MeetingsAdmin() {
   const [items, setItems] = useState<MeetingRequest[] | null>(null);
   const [drafts, setDrafts] = useState<Record<string, { scheduledAt: string; adminResponse: string }>>({});
+  const [saving, setSaving] = useState<Record<string, boolean>>({});
 
   const load = () =>
     adminListMeetingRequests()
@@ -178,12 +189,16 @@ function MeetingsAdmin() {
   }, []);
 
   const update = async (id: string, payload: Parameters<typeof adminUpdateMeetingRequest>[1]) => {
+    if (saving[id]) return;
+    setSaving((s) => ({ ...s, [id]: true }));
     try {
       await adminUpdateMeetingRequest(id, payload);
       toast.success("Updated");
       load();
     } catch (e) {
       toast.error(e instanceof Error ? e.message : "Update failed");
+    } finally {
+      setSaving((s) => ({ ...s, [id]: false }));
     }
   };
 
@@ -245,8 +260,10 @@ function MeetingsAdmin() {
                       adminResponse: draft.adminResponse,
                     })
                   }
-                  className="inline-flex items-center gap-2 rounded-xl bg-indigo-500 px-4 py-1.5 text-sm font-medium text-white hover:bg-indigo-600"
+                  disabled={Boolean(saving[m._id])}
+                  className="inline-flex items-center gap-2 rounded-xl bg-indigo-500 px-4 py-1.5 text-sm font-medium text-white hover:bg-indigo-600 disabled:opacity-50 disabled:cursor-not-allowed"
                 >
+                  {saving[m._id] ? <Loader2 className="animate-spin" size={12} /> : null}
                   Save
                 </button>
               </div>

--- a/app/(pages)/admin/support/page.tsx
+++ b/app/(pages)/admin/support/page.tsx
@@ -29,7 +29,11 @@ export default function AdminSupportPage() {
 
   useEffect(() => {
     if (loading) return;
-    if (!isAuthenticated || user?.role !== "admin") router.replace("/login");
+    if (!isAuthenticated) {
+      router.replace("/login");
+    } else if (user?.role !== "admin") {
+      router.replace("/dashboard");
+    }
   }, [user, isAuthenticated, loading, router]);
 
   if (loading || !isAuthenticated || user?.role !== "admin") {
@@ -43,7 +47,7 @@ export default function AdminSupportPage() {
   return (
     <div className="min-h-screen bg-gradient-to-br from-indigo-50 via-blue-50 to-white pb-16 pt-24">
       <div className="mx-auto max-w-6xl px-6">
-        <h1 className="text-3xl font-bold text-indigo-900">Professional Support</h1>
+        <h1 className="text-3xl font-bold text-indigo-900">Support — Admin</h1>
         <p className="mt-1 text-sm text-indigo-600/80">Tickets and meeting requests from professionals.</p>
 
         <div className="mt-6 flex gap-2">
@@ -243,7 +247,18 @@ function MeetingsAdmin() {
                   id={`meeting-status-${m._id}`}
                   aria-label={`Meeting status for "${m.topic}"`}
                   value={m.status}
-                  onChange={(e) => update(m._id, { status: e.target.value as MeetingRequestStatus })}
+                  onChange={(e) => {
+                    const next = e.target.value as MeetingRequestStatus;
+                    if (next === "scheduled" && !draft.scheduledAt && !m.scheduledAt) {
+                      toast.error("Set a scheduled time before marking as scheduled");
+                      return;
+                    }
+                    const payload: Parameters<typeof adminUpdateMeetingRequest>[1] = { status: next };
+                    if (next === "scheduled" && draft.scheduledAt) {
+                      payload.scheduledAt = new Date(draft.scheduledAt).toISOString();
+                    }
+                    update(m._id, payload);
+                  }}
                   className="rounded-xl border border-indigo-200 bg-white px-3 py-1.5 text-xs outline-none focus:border-indigo-400 focus:ring-2 focus:ring-indigo-200"
                 >
                   {MEETING_STATUSES.map((s) => (
@@ -275,12 +290,17 @@ function MeetingsAdmin() {
               </div>
               <div className="flex justify-end">
                 <button
-                  onClick={() =>
-                    update(m._id, {
+                  onClick={() => {
+                    const payload: Parameters<typeof adminUpdateMeetingRequest>[1] = {
                       scheduledAt: draft.scheduledAt ? new Date(draft.scheduledAt).toISOString() : undefined,
                       adminResponse: draft.adminResponse,
-                    })
-                  }
+                    };
+                    // If admin has set a time but status is still pending, auto-advance to scheduled
+                    if (draft.scheduledAt && m.status === "pending") {
+                      payload.status = "scheduled";
+                    }
+                    update(m._id, payload);
+                  }}
                   disabled={Boolean(saving[m._id])}
                   className="inline-flex items-center gap-2 rounded-xl bg-indigo-500 px-4 py-1.5 text-sm font-medium text-white hover:bg-indigo-600 disabled:opacity-50 disabled:cursor-not-allowed"
                 >

--- a/app/(pages)/admin/support/page.tsx
+++ b/app/(pages)/admin/support/page.tsx
@@ -84,9 +84,10 @@ function TicketsAdmin() {
 
   const load = () =>
     adminListTickets()
-      .then(setItems)
+      .then((next) => setItems(next))
       .catch((e) => {
-        setItems([]);
+        // Preserve prior items on refresh failure; only fall back to [] on first load
+        setItems((prev) => (prev === null ? [] : prev));
         toast.error(e instanceof Error ? e.message : "Failed to load tickets");
       });
 
@@ -129,6 +130,8 @@ function TicketsAdmin() {
                   </p>
                 </div>
                 <select
+                  id={`ticket-status-${t._id}`}
+                  aria-label={`Status for ticket "${t.subject}"`}
                   value={t.status}
                   onChange={(e) => update(t._id, { status: e.target.value as SupportTicketStatus })}
                   className="rounded-xl border border-indigo-200 bg-white px-3 py-1.5 text-xs outline-none focus:border-indigo-400 focus:ring-2 focus:ring-indigo-200"
@@ -154,6 +157,8 @@ function TicketsAdmin() {
               )}
               <div className="mt-3 flex items-center gap-2">
                 <input
+                  id={`ticket-reply-${t._id}`}
+                  aria-label={`Reply to ticket "${t.subject}"`}
                   value={reply[t._id] || ""}
                   onChange={(e) => setReply((r) => ({ ...r, [t._id]: e.target.value }))}
                   disabled={Boolean(saving[t._id])}
@@ -192,9 +197,9 @@ function MeetingsAdmin() {
 
   const load = () =>
     adminListMeetingRequests()
-      .then(setItems)
+      .then((next) => setItems(next))
       .catch((e) => {
-        setItems([]);
+        setItems((prev) => (prev === null ? [] : prev));
         toast.error(e instanceof Error ? e.message : "Failed to load");
       });
 
@@ -235,6 +240,8 @@ function MeetingsAdmin() {
                   </p>
                 </div>
                 <select
+                  id={`meeting-status-${m._id}`}
+                  aria-label={`Meeting status for "${m.topic}"`}
                   value={m.status}
                   onChange={(e) => update(m._id, { status: e.target.value as MeetingRequestStatus })}
                   className="rounded-xl border border-indigo-200 bg-white px-3 py-1.5 text-xs outline-none focus:border-indigo-400 focus:ring-2 focus:ring-indigo-200"

--- a/app/(pages)/admin/support/page.tsx
+++ b/app/(pages)/admin/support/page.tsx
@@ -85,7 +85,10 @@ function TicketsAdmin() {
   const load = () =>
     adminListTickets()
       .then(setItems)
-      .catch((e) => toast.error(e instanceof Error ? e.message : "Failed to load tickets"));
+      .catch((e) => {
+        setItems([]);
+        toast.error(e instanceof Error ? e.message : "Failed to load tickets");
+      });
 
   useEffect(() => {
     load();
@@ -174,6 +177,14 @@ function TicketsAdmin() {
   );
 }
 
+function formatForDatetimeLocal(value: string | Date | undefined): string {
+  if (!value) return "";
+  const d = value instanceof Date ? value : new Date(value);
+  if (Number.isNaN(d.getTime())) return "";
+  const local = new Date(d.getTime() - d.getTimezoneOffset() * 60000);
+  return local.toISOString().slice(0, 16);
+}
+
 function MeetingsAdmin() {
   const [items, setItems] = useState<MeetingRequest[] | null>(null);
   const [drafts, setDrafts] = useState<Record<string, { scheduledAt: string; adminResponse: string }>>({});
@@ -182,7 +193,10 @@ function MeetingsAdmin() {
   const load = () =>
     adminListMeetingRequests()
       .then(setItems)
-      .catch((e) => toast.error(e instanceof Error ? e.message : "Failed to load"));
+      .catch((e) => {
+        setItems([]);
+        toast.error(e instanceof Error ? e.message : "Failed to load");
+      });
 
   useEffect(() => {
     load();
@@ -209,7 +223,7 @@ function MeetingsAdmin() {
     <div className="space-y-3">
       {items.map((m) => {
         const u = typeof m.userId === "object" ? m.userId : null;
-        const draft = drafts[m._id] || { scheduledAt: m.scheduledAt ? new Date(m.scheduledAt).toISOString().slice(0, 16) : "", adminResponse: m.adminResponse || "" };
+        const draft = drafts[m._id] || { scheduledAt: formatForDatetimeLocal(m.scheduledAt), adminResponse: m.adminResponse || "" };
         return (
           <div key={m._id} className="rounded-2xl bg-gradient-to-br from-indigo-100 via-blue-100 to-cyan-100 p-[1.5px]">
             <div className="rounded-[calc(1rem-1.5px)] bg-white p-5 space-y-2">

--- a/app/(pages)/blog/[slug]/page.tsx
+++ b/app/(pages)/blog/[slug]/page.tsx
@@ -3,7 +3,7 @@ import Image from "next/image";
 import { notFound } from "next/navigation";
 import { ArrowLeft, Calendar, Tag } from "lucide-react";
 import type { Metadata } from "next";
-import { publicGetCms } from "@/lib/cms";
+import { publicGetCms, cmsAuthorName } from "@/lib/cms";
 import RichTextRenderer from "@/components/cms/RichTextRenderer";
 import { buildMetadata } from "@/lib/seo/metadata";
 import JsonLd from "@/components/seo/JsonLd";
@@ -34,7 +34,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     keywords: post.tags,
     publishedTime: post.publishedAt,
     modifiedTime: post.updatedAt,
-    authorName: typeof post.author === "object" && post.author ? post.author.name : undefined,
+    authorName: cmsAuthorName(post),
   });
 }
 
@@ -48,7 +48,7 @@ export default async function BlogDetailPage({ params }: Props) {
   }
   if (!post) notFound();
 
-  const authorName = typeof post.author === "object" && post.author ? post.author.name : undefined;
+  const authorName = cmsAuthorName(post);
   const date = post.publishedAt || post.updatedAt;
 
   return (

--- a/app/(pages)/dashboard/favorites/page.tsx
+++ b/app/(pages)/dashboard/favorites/page.tsx
@@ -32,7 +32,7 @@ interface FavoriteItem {
 export default function FavoritesPage() {
   const router = useRouter();
   const { user, isAuthenticated, loading } = useAuth();
-  const [tab, setTab] = useState<"professional" | "project">("professional");
+  const [tab, setTab] = useState<"professional" | "project">("project");
   const [items, setItems] = useState<FavoriteItem[]>([]);
   const [listLoading, setListLoading] = useState(false);
   const requestIdRef = useRef(0);
@@ -96,8 +96,8 @@ export default function FavoritesPage() {
 
       <Tabs value={tab} onValueChange={(v) => setTab(v as "professional" | "project")}>
         <TabsList>
-          <TabsTrigger value="professional">Professionals</TabsTrigger>
           <TabsTrigger value="project">Projects</TabsTrigger>
+          <TabsTrigger value="professional">Professionals</TabsTrigger>
         </TabsList>
 
         <TabsContent value="professional" className="mt-6">

--- a/app/(pages)/dashboard/page.tsx
+++ b/app/(pages)/dashboard/page.tsx
@@ -4,7 +4,7 @@ import { useAuth } from "@/contexts/AuthContext"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
 import { Badge } from "@/components/ui/badge"
-import { User, Mail, Phone, Shield, Calendar, Crown, Settings, TrendingUp, Users, Award, CheckCircle, XCircle, Clock, AlertTriangle, Plus, Briefcase, Package, CreditCard, FileText, Star, Gift, Play, Loader2, Info, MessageSquareWarning, EyeOff, Heart } from "lucide-react"
+import { User, Mail, Phone, Shield, Calendar, Crown, Settings, TrendingUp, Users, Award, CheckCircle, XCircle, Clock, AlertTriangle, Plus, Briefcase, Package, CreditCard, FileText, Star, Gift, Play, Loader2, Info, MessageSquareWarning, EyeOff, Heart, LifeBuoy } from "lucide-react"
 import { useRouter } from "next/navigation"
 import { useEffect, useMemo, useState } from "react"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
@@ -707,6 +707,25 @@ export default function DashboardPage() {
                   >
                     <FileText className="h-4 w-4 mr-2" />
                     Manage Content
+                  </Button>
+                </CardContent>
+              </Card>
+
+              <Card className="border-indigo-100 bg-gradient-to-br from-white via-indigo-50 to-blue-100 shadow-md transition-all duration-200 hover:-translate-y-1 hover:shadow-xl">
+                <CardHeader>
+                  <CardTitle className="flex items-center gap-2">
+                    <LifeBuoy className="h-5 w-5 text-indigo-500" />
+                    Professional Support
+                  </CardTitle>
+                  <CardDescription>Review tickets and meeting requests from professionals</CardDescription>
+                </CardHeader>
+                <CardContent>
+                  <Button
+                    onClick={() => window.open('/admin/support', '_blank')}
+                    className="w-full bg-gradient-to-r from-indigo-500 to-blue-500 hover:from-indigo-600 hover:to-blue-600"
+                  >
+                    <LifeBuoy className="h-4 w-4 mr-2" />
+                    Open Support Inbox
                   </Button>
                 </CardContent>
               </Card>

--- a/app/(pages)/news/[slug]/page.tsx
+++ b/app/(pages)/news/[slug]/page.tsx
@@ -57,6 +57,7 @@ export default async function NewsDetailPage({ params }: Props) {
             image: post.coverImage,
             datePublished: post.publishedAt,
             dateModified: post.updatedAt,
+            authorName,
           }),
           breadcrumbSchema([
             { name: "Home", path: "/" },

--- a/app/(pages)/news/[slug]/page.tsx
+++ b/app/(pages)/news/[slug]/page.tsx
@@ -2,7 +2,7 @@ import Link from "next/link";
 import { notFound } from "next/navigation";
 import { ArrowLeft, Calendar } from "lucide-react";
 import type { Metadata } from "next";
-import { publicGetCms } from "@/lib/cms";
+import { publicGetCms, cmsAuthorName } from "@/lib/cms";
 import RichTextRenderer from "@/components/cms/RichTextRenderer";
 import { buildMetadata } from "@/lib/seo/metadata";
 import JsonLd from "@/components/seo/JsonLd";
@@ -44,6 +44,7 @@ export default async function NewsDetailPage({ params }: Props) {
   if (!post) notFound();
 
   const date = post.publishedAt || post.updatedAt;
+  const authorName = cmsAuthorName(post);
 
   return (
     <article className="min-h-screen bg-gradient-to-br from-rose-50 via-pink-50 to-white pb-20">
@@ -80,12 +81,15 @@ export default async function NewsDetailPage({ params }: Props) {
         <h1 className="bg-gradient-to-r from-rose-700 via-pink-600 to-rose-500 bg-clip-text text-4xl font-bold text-transparent md:text-5xl">
           {post.title}
         </h1>
-        {date && (
-          <div className="mt-4 inline-flex items-center gap-1 text-sm text-rose-500">
-            <Calendar size={14} />
-            {new Date(date).toLocaleDateString(undefined, { month: "long", day: "numeric", year: "numeric" })}
-          </div>
-        )}
+        <div className="mt-4 flex items-center gap-3 text-sm text-rose-500">
+          {date && (
+            <span className="inline-flex items-center gap-1">
+              <Calendar size={14} />
+              {new Date(date).toLocaleDateString(undefined, { month: "long", day: "numeric", year: "numeric" })}
+            </span>
+          )}
+          {authorName && <span>· by {authorName}</span>}
+        </div>
         <div className="mt-8">
           <RichTextRenderer html={post.body} className="prose-lg" />
         </div>

--- a/app/(pages)/professional/onboarding/page.tsx
+++ b/app/(pages)/professional/onboarding/page.tsx
@@ -19,6 +19,8 @@ import { getAuthToken, buildUsernameSuggestionParams } from '@/lib/utils'
 import { formatVATNumber, getVATCountryName, isEUVatNumber, validateVATFormat, validateVATWithAPI, updateProfessionalBusinessProfile, submitForVerification, COUNTRY_NAMES } from '@/lib/vatValidation'
 import { CompanyAvailability, DayAvailability, DEFAULT_COMPANY_AVAILABILITY } from '@/lib/defaults/companyAvailability'
 import { ONBOARDING_STEPS } from '@/lib/constants/onboardingSteps'
+import Link from 'next/link'
+import { publicListPolicyLinks, PolicyLink } from '@/lib/cms'
 
 const STEPS = [
   { id: ONBOARDING_STEPS.ID_UPLOAD, title: 'ID Upload', icon: Shield, required: true, gradient: 'from-violet-200 via-purple-200 to-fuchsia-200' },
@@ -1062,6 +1064,25 @@ function EmployeesStep({ gradient, setCurrentStep }: { gradient: string; setCurr
   )
 }
 
+function AgreementLabel({ policySlug, policies, children }: { policySlug: string; policies: PolicyLink[]; children: React.ReactNode }) {
+  const match = policies.find((p) => p.slug === policySlug)
+  if (!match) return <>{children}</>
+  return (
+    <>
+      {children}{' '}
+      <Link
+        href={match.path}
+        target="_blank"
+        rel="noopener noreferrer"
+        onClick={(e) => e.stopPropagation()}
+        className="text-indigo-600 underline underline-offset-2 hover:text-indigo-700"
+      >
+        (read)
+      </Link>
+    </>
+  )
+}
+
 function AgreementsStep({
   gradient,
   agreements,
@@ -1079,6 +1100,11 @@ function AgreementsStep({
   handleSubmit: () => void
   submitting: boolean
 }) {
+  const [policies, setPolicies] = useState<PolicyLink[]>([])
+  useEffect(() => {
+    publicListPolicyLinks().then(setPolicies).catch(() => setPolicies([]))
+  }, [])
+
   return (
     <GradientCard gradient={gradient}>
       <div className="p-6 sm:p-8 space-y-6">
@@ -1132,7 +1158,11 @@ function AgreementsStep({
               onCheckedChange={(checked) => setAgreements((prev) => ({ ...prev, rulesAccepted: Boolean(checked) }))}
               className="mt-0.5"
             />
-            <span className="text-sm text-gray-700 leading-relaxed">I agree to the platform rules and consequences</span>
+            <span className="text-sm text-gray-700 leading-relaxed">
+              <AgreementLabel policySlug="platform-rules" policies={policies}>
+                I agree to the platform rules and consequences
+              </AgreementLabel>
+            </span>
           </label>
 
           <label className={`flex items-start gap-3 p-4 rounded-xl border cursor-pointer transition-colors ${
@@ -1143,7 +1173,11 @@ function AgreementsStep({
               onCheckedChange={(checked) => setAgreements((prev) => ({ ...prev, termsAccepted: Boolean(checked) }))}
               className="mt-0.5"
             />
-            <span className="text-sm text-gray-700 leading-relaxed">I accept the General Terms & Conditions</span>
+            <span className="text-sm text-gray-700 leading-relaxed">
+              <AgreementLabel policySlug="terms-of-service" policies={policies}>
+                I accept the General Terms &amp; Conditions
+              </AgreementLabel>
+            </span>
           </label>
 
           <label className={`flex items-start gap-3 p-4 rounded-xl border cursor-pointer transition-colors ${
@@ -1154,7 +1188,11 @@ function AgreementsStep({
               onCheckedChange={(checked) => setAgreements((prev) => ({ ...prev, selfBillingAccepted: Boolean(checked) }))}
               className="mt-0.5"
             />
-            <span className="text-sm text-gray-700 leading-relaxed">I agree that Fixera prepares and issues invoices on my behalf (self-billing agreement)</span>
+            <span className="text-sm text-gray-700 leading-relaxed">
+              <AgreementLabel policySlug="self-billing-agreement" policies={policies}>
+                I agree that Fixera prepares and issues invoices on my behalf (self-billing agreement)
+              </AgreementLabel>
+            </span>
           </label>
         </div>
 

--- a/app/(pages)/professional/support/page.tsx
+++ b/app/(pages)/professional/support/page.tsx
@@ -1,0 +1,393 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { toast } from "sonner";
+import { Loader2, LifeBuoy, CalendarClock, MessageCircle, Send, Plus } from "lucide-react";
+import { useAuth } from "@/contexts/AuthContext";
+import { cn } from "@/lib/utils";
+import {
+  proCreateMeetingRequest,
+  proCreateTicket,
+  proListMyMeetingRequests,
+  proListMyTickets,
+  proReplyTicket,
+  SupportTicket,
+  MeetingRequest,
+} from "@/lib/support";
+
+type Tab = "ticket" | "meeting" | "chat";
+
+export default function ProfessionalSupportPage() {
+  const { user, isAuthenticated, loading } = useAuth();
+  const router = useRouter();
+  const [tab, setTab] = useState<Tab>("ticket");
+
+  useEffect(() => {
+    if (loading) return;
+    if (!isAuthenticated || user?.role !== "professional") {
+      router.replace("/login?redirect=/professional/support");
+    }
+  }, [user, isAuthenticated, loading, router]);
+
+  if (loading || !isAuthenticated || user?.role !== "professional") {
+    return (
+      <div className="flex min-h-[60vh] items-center justify-center bg-gradient-to-br from-indigo-50 via-blue-50 to-white">
+        <Loader2 className="animate-spin text-indigo-500" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-indigo-50 via-blue-50 to-white pb-16">
+      <div className="mx-auto max-w-4xl px-6 pt-24">
+        <div className="rounded-3xl bg-gradient-to-br from-indigo-200 via-blue-200 to-cyan-200 p-[1.5px] shadow-md">
+          <div className="rounded-[calc(1.5rem-1.5px)] bg-white px-8 py-8">
+            <h1 className="text-3xl font-bold text-indigo-900">Professional Support</h1>
+            <p className="mt-1 text-sm text-indigo-600/80">Open a ticket, request a meeting, or chat with us.</p>
+          </div>
+        </div>
+
+        <div className="mt-6 flex flex-wrap gap-2">
+          <TabButton active={tab === "ticket"} onClick={() => setTab("ticket")} icon={<LifeBuoy size={14} />}>
+            Create ticket
+          </TabButton>
+          <TabButton active={tab === "meeting"} onClick={() => setTab("meeting")} icon={<CalendarClock size={14} />}>
+            Plan a meeting
+          </TabButton>
+          <TabButton active={tab === "chat"} onClick={() => setTab("chat")} icon={<MessageCircle size={14} />}>
+            Chat
+          </TabButton>
+        </div>
+
+        <div className="mt-6">
+          {tab === "ticket" && <TicketsTab />}
+          {tab === "meeting" && <MeetingsTab />}
+          {tab === "chat" && <ChatPlaceholder />}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function TabButton({ children, active, onClick, icon }: { children: React.ReactNode; active: boolean; onClick: () => void; icon?: React.ReactNode }) {
+  return (
+    <button
+      onClick={onClick}
+      className={cn(
+        "inline-flex items-center gap-2 rounded-xl border px-4 py-2 text-sm font-medium transition",
+        active
+          ? "border-transparent bg-gradient-to-r from-indigo-500 to-blue-500 text-white shadow-md shadow-indigo-200"
+          : "border-indigo-200 bg-white/60 text-indigo-700 hover:bg-indigo-50"
+      )}
+    >
+      {icon}
+      {children}
+    </button>
+  );
+}
+
+function Card({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="rounded-2xl bg-gradient-to-br from-indigo-100 via-blue-100 to-cyan-100 p-[1.5px] shadow-sm">
+      <div className="rounded-[calc(1rem-1.5px)] bg-white">{children}</div>
+    </div>
+  );
+}
+
+function TicketsTab() {
+  const [items, setItems] = useState<SupportTicket[] | null>(null);
+  const [subject, setSubject] = useState("");
+  const [description, setDescription] = useState("");
+  const [saving, setSaving] = useState(false);
+  const [replyDraft, setReplyDraft] = useState<Record<string, string>>({});
+
+  const load = () =>
+    proListMyTickets()
+      .then(setItems)
+      .catch((e) => toast.error(e instanceof Error ? e.message : "Failed to load tickets"));
+
+  useEffect(() => {
+    load();
+  }, []);
+
+  const submit = async () => {
+    if (!subject.trim() || !description.trim()) {
+      toast.error("Subject and description are required");
+      return;
+    }
+    setSaving(true);
+    try {
+      await proCreateTicket({ subject: subject.trim(), description: description.trim() });
+      setSubject("");
+      setDescription("");
+      toast.success("Ticket created");
+      load();
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : "Failed to create ticket");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const sendReply = async (id: string) => {
+    const body = replyDraft[id]?.trim();
+    if (!body) return;
+    try {
+      await proReplyTicket(id, body);
+      setReplyDraft((d) => ({ ...d, [id]: "" }));
+      toast.success("Reply sent");
+      load();
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : "Failed to reply");
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      <Card>
+        <div className="space-y-3 p-6">
+          <h2 className="text-sm font-semibold uppercase tracking-wide text-indigo-700">New ticket</h2>
+          <input
+            value={subject}
+            onChange={(e) => setSubject(e.target.value)}
+            placeholder="Subject"
+            maxLength={200}
+            className="w-full rounded-xl border border-indigo-200 bg-white/60 px-4 py-2 text-sm outline-none transition focus:border-indigo-400 focus:bg-white focus:ring-2 focus:ring-indigo-200"
+          />
+          <textarea
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            rows={4}
+            placeholder="Describe the issue in detail"
+            maxLength={5000}
+            className="w-full resize-none rounded-xl border border-indigo-200 bg-white/60 px-4 py-2 text-sm outline-none transition focus:border-indigo-400 focus:bg-white focus:ring-2 focus:ring-indigo-200"
+          />
+          <div className="flex justify-end">
+            <button
+              onClick={submit}
+              disabled={saving}
+              className="inline-flex items-center gap-2 rounded-xl bg-gradient-to-r from-indigo-500 to-blue-500 px-5 py-2 text-sm font-semibold text-white shadow-md shadow-indigo-200 transition hover:shadow-lg hover:shadow-indigo-300 disabled:opacity-50"
+            >
+              {saving ? <Loader2 className="animate-spin" size={14} /> : <Plus size={14} />} Create ticket
+            </button>
+          </div>
+        </div>
+      </Card>
+
+      <div>
+        <h2 className="mb-3 text-sm font-semibold uppercase tracking-wide text-indigo-700">Your tickets</h2>
+        {items === null ? (
+          <div className="flex justify-center py-10">
+            <Loader2 className="animate-spin text-indigo-500" />
+          </div>
+        ) : items.length === 0 ? (
+          <div className="rounded-2xl border border-dashed border-indigo-300 bg-gradient-to-br from-indigo-50 via-blue-50 to-white py-10 text-center text-sm text-indigo-500">
+            No tickets yet.
+          </div>
+        ) : (
+          <div className="space-y-3">
+            {items.map((t) => (
+              <Card key={t._id}>
+                <div className="space-y-2 p-5">
+                  <div className="flex items-center justify-between gap-3">
+                    <h3 className="font-semibold text-indigo-900">{t.subject}</h3>
+                    <StatusPill label={t.status} />
+                  </div>
+                  <p className="whitespace-pre-wrap text-sm text-indigo-800/80">{t.description}</p>
+                  {t.replies.length > 0 && (
+                    <div className="mt-2 space-y-1.5 border-l-2 border-indigo-200 pl-3">
+                      {t.replies.map((r, idx) => (
+                        <div key={idx} className="text-xs">
+                          <span className={cn("font-semibold", r.authorRole === "admin" ? "text-blue-700" : "text-indigo-700")}>
+                            {r.authorRole === "admin" ? "Admin" : "You"}
+                          </span>
+                          <span className="text-indigo-400"> · {new Date(r.createdAt).toLocaleString()}</span>
+                          <div className="whitespace-pre-wrap text-indigo-800/90">{r.body}</div>
+                        </div>
+                      ))}
+                    </div>
+                  )}
+                  {t.status !== "closed" && (
+                    <div className="flex items-center gap-2">
+                      <input
+                        value={replyDraft[t._id] || ""}
+                        onChange={(e) => setReplyDraft((d) => ({ ...d, [t._id]: e.target.value }))}
+                        placeholder="Reply…"
+                        className="flex-1 rounded-xl border border-indigo-200 bg-white/60 px-3 py-1.5 text-sm outline-none focus:border-indigo-400 focus:bg-white focus:ring-2 focus:ring-indigo-200"
+                      />
+                      <button
+                        onClick={() => sendReply(t._id)}
+                        className="inline-flex items-center gap-1 rounded-xl bg-indigo-500 px-3 py-1.5 text-sm font-medium text-white hover:bg-indigo-600"
+                      >
+                        <Send size={12} /> Send
+                      </button>
+                    </div>
+                  )}
+                </div>
+              </Card>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function MeetingsTab() {
+  const [items, setItems] = useState<MeetingRequest[] | null>(null);
+  const [topic, setTopic] = useState("");
+  const [preferredTimes, setPreferredTimes] = useState("");
+  const [durationMinutes, setDurationMinutes] = useState(30);
+  const [saving, setSaving] = useState(false);
+
+  const load = () =>
+    proListMyMeetingRequests()
+      .then(setItems)
+      .catch((e) => toast.error(e instanceof Error ? e.message : "Failed to load requests"));
+
+  useEffect(() => {
+    load();
+  }, []);
+
+  const submit = async () => {
+    if (!topic.trim() || !preferredTimes.trim()) {
+      toast.error("Topic and preferred times are required");
+      return;
+    }
+    setSaving(true);
+    try {
+      await proCreateMeetingRequest({ topic: topic.trim(), preferredTimes: preferredTimes.trim(), durationMinutes });
+      setTopic("");
+      setPreferredTimes("");
+      setDurationMinutes(30);
+      toast.success("Meeting request sent");
+      load();
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : "Failed to submit");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      <Card>
+        <div className="space-y-3 p-6">
+          <h2 className="text-sm font-semibold uppercase tracking-wide text-indigo-700">Request a meeting</h2>
+          <input
+            value={topic}
+            onChange={(e) => setTopic(e.target.value)}
+            placeholder="Topic"
+            maxLength={200}
+            className="w-full rounded-xl border border-indigo-200 bg-white/60 px-4 py-2 text-sm outline-none focus:border-indigo-400 focus:bg-white focus:ring-2 focus:ring-indigo-200"
+          />
+          <textarea
+            value={preferredTimes}
+            onChange={(e) => setPreferredTimes(e.target.value)}
+            rows={3}
+            placeholder="Preferred dates/times (e.g. 'Mon–Wed morning, any time after 10:00')"
+            maxLength={1000}
+            className="w-full resize-none rounded-xl border border-indigo-200 bg-white/60 px-4 py-2 text-sm outline-none focus:border-indigo-400 focus:bg-white focus:ring-2 focus:ring-indigo-200"
+          />
+          <div className="flex items-center gap-3">
+            <label className="text-sm text-indigo-700">Duration</label>
+            <select
+              value={durationMinutes}
+              onChange={(e) => setDurationMinutes(Number(e.target.value))}
+              className="rounded-xl border border-indigo-200 bg-white px-3 py-1.5 text-sm outline-none focus:border-indigo-400 focus:ring-2 focus:ring-indigo-200"
+            >
+              <option value={15}>15 minutes</option>
+              <option value={30}>30 minutes</option>
+              <option value={45}>45 minutes</option>
+              <option value={60}>60 minutes</option>
+              <option value={90}>90 minutes</option>
+              <option value={120}>2 hours</option>
+            </select>
+          </div>
+          <div className="flex justify-end">
+            <button
+              onClick={submit}
+              disabled={saving}
+              className="inline-flex items-center gap-2 rounded-xl bg-gradient-to-r from-indigo-500 to-blue-500 px-5 py-2 text-sm font-semibold text-white shadow-md shadow-indigo-200 transition hover:shadow-lg hover:shadow-indigo-300 disabled:opacity-50"
+            >
+              {saving ? <Loader2 className="animate-spin" size={14} /> : <CalendarClock size={14} />} Submit request
+            </button>
+          </div>
+          <p className="text-[11px] text-indigo-400">Admin will confirm with a scheduled time. Availability-based booking is coming soon.</p>
+        </div>
+      </Card>
+
+      <div>
+        <h2 className="mb-3 text-sm font-semibold uppercase tracking-wide text-indigo-700">Your requests</h2>
+        {items === null ? (
+          <div className="flex justify-center py-10">
+            <Loader2 className="animate-spin text-indigo-500" />
+          </div>
+        ) : items.length === 0 ? (
+          <div className="rounded-2xl border border-dashed border-indigo-300 bg-gradient-to-br from-indigo-50 via-blue-50 to-white py-10 text-center text-sm text-indigo-500">
+            No meeting requests yet.
+          </div>
+        ) : (
+          <div className="space-y-3">
+            {items.map((m) => (
+              <Card key={m._id}>
+                <div className="space-y-1 p-5">
+                  <div className="flex items-center justify-between gap-3">
+                    <h3 className="font-semibold text-indigo-900">{m.topic}</h3>
+                    <StatusPill label={m.status} />
+                  </div>
+                  <p className="text-sm text-indigo-700/80">Preferred: {m.preferredTimes}</p>
+                  <p className="text-xs text-indigo-500">Duration: {m.durationMinutes} min</p>
+                  {m.scheduledAt && (
+                    <p className="text-sm font-medium text-emerald-700">Scheduled for: {new Date(m.scheduledAt).toLocaleString()}</p>
+                  )}
+                  {m.adminResponse && (
+                    <div className="rounded-xl bg-indigo-50 px-3 py-2 text-xs text-indigo-800">
+                      <span className="font-semibold">Admin: </span>
+                      {m.adminResponse}
+                    </div>
+                  )}
+                </div>
+              </Card>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function ChatPlaceholder() {
+  return (
+    <Card>
+      <div className="p-10 text-center">
+        <div className="mx-auto mb-4 grid h-14 w-14 place-items-center rounded-2xl bg-gradient-to-br from-indigo-400 to-blue-500 text-white shadow-md shadow-indigo-200">
+          <MessageCircle size={24} />
+        </div>
+        <h2 className="text-lg font-semibold text-indigo-900">AI chat is coming soon</h2>
+        <p className="mx-auto mt-2 max-w-md text-sm text-indigo-600/80">
+          You&apos;ll be able to chat with our AI assistant here. If your question needs a human, we&apos;ll escalate to a live agent automatically.
+        </p>
+      </div>
+    </Card>
+  );
+}
+
+function StatusPill({ label }: { label: string }) {
+  const cls: Record<string, string> = {
+    open: "bg-amber-100 text-amber-700",
+    in_progress: "bg-blue-100 text-blue-700",
+    resolved: "bg-emerald-100 text-emerald-700",
+    closed: "bg-gray-100 text-gray-600",
+    pending: "bg-amber-100 text-amber-700",
+    scheduled: "bg-emerald-100 text-emerald-700",
+    declined: "bg-rose-100 text-rose-700",
+    cancelled: "bg-gray-100 text-gray-600",
+  };
+  return (
+    <span className={cn("rounded-full px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide", cls[label] || "bg-gray-100 text-gray-600")}>
+      {label.replace("_", " ")}
+    </span>
+  );
+}

--- a/app/(pages)/professional/support/page.tsx
+++ b/app/(pages)/professional/support/page.tsx
@@ -107,7 +107,10 @@ function TicketsTab() {
     () =>
       proListMyTickets()
         .then(setItems)
-        .catch((e) => toast.error(e instanceof Error ? e.message : "Failed to load tickets")),
+        .catch((e) => {
+          setItems([]);
+          toast.error(e instanceof Error ? e.message : "Failed to load tickets");
+        }),
     []
   );
 
@@ -160,6 +163,7 @@ function TicketsTab() {
             value={subject}
             onChange={(e) => setSubject(e.target.value)}
             placeholder="Subject"
+            aria-label="Ticket subject"
             maxLength={200}
             className="w-full rounded-xl border border-indigo-200 bg-white/60 px-4 py-2 text-sm outline-none transition focus:border-indigo-400 focus:bg-white focus:ring-2 focus:ring-indigo-200"
           />
@@ -168,6 +172,7 @@ function TicketsTab() {
             onChange={(e) => setDescription(e.target.value)}
             rows={4}
             placeholder="Describe the issue in detail"
+            aria-label="Ticket description"
             maxLength={5000}
             className="w-full resize-none rounded-xl border border-indigo-200 bg-white/60 px-4 py-2 text-sm outline-none transition focus:border-indigo-400 focus:bg-white focus:ring-2 focus:ring-indigo-200"
           />
@@ -223,6 +228,7 @@ function TicketsTab() {
                         onChange={(e) => setReplyDraft((d) => ({ ...d, [t._id]: e.target.value }))}
                         disabled={Boolean(replySending[t._id])}
                         placeholder="Reply…"
+                        aria-label={`Reply to ticket ${t.subject}`}
                         className="flex-1 rounded-xl border border-indigo-200 bg-white/60 px-3 py-1.5 text-sm outline-none focus:border-indigo-400 focus:bg-white focus:ring-2 focus:ring-indigo-200 disabled:opacity-50"
                       />
                       <button
@@ -255,7 +261,10 @@ function MeetingsTab() {
     () =>
       proListMyMeetingRequests()
         .then(setItems)
-        .catch((e) => toast.error(e instanceof Error ? e.message : "Failed to load requests")),
+        .catch((e) => {
+          setItems([]);
+          toast.error(e instanceof Error ? e.message : "Failed to load requests");
+        }),
     []
   );
 
@@ -292,6 +301,7 @@ function MeetingsTab() {
             value={topic}
             onChange={(e) => setTopic(e.target.value)}
             placeholder="Topic"
+            aria-label="Meeting topic"
             maxLength={200}
             className="w-full rounded-xl border border-indigo-200 bg-white/60 px-4 py-2 text-sm outline-none focus:border-indigo-400 focus:bg-white focus:ring-2 focus:ring-indigo-200"
           />
@@ -300,12 +310,14 @@ function MeetingsTab() {
             onChange={(e) => setPreferredTimes(e.target.value)}
             rows={3}
             placeholder="Preferred dates/times (e.g. 'Mon–Wed morning, any time after 10:00')"
+            aria-label="Preferred dates and times"
             maxLength={1000}
             className="w-full resize-none rounded-xl border border-indigo-200 bg-white/60 px-4 py-2 text-sm outline-none focus:border-indigo-400 focus:bg-white focus:ring-2 focus:ring-indigo-200"
           />
           <div className="flex items-center gap-3">
-            <label className="text-sm text-indigo-700">Duration</label>
+            <label htmlFor="meeting-duration" className="text-sm text-indigo-700">Duration</label>
             <select
+              id="meeting-duration"
               value={durationMinutes}
               onChange={(e) => setDurationMinutes(Number(e.target.value))}
               className="rounded-xl border border-indigo-200 bg-white px-3 py-1.5 text-sm outline-none focus:border-indigo-400 focus:ring-2 focus:ring-indigo-200"

--- a/app/(pages)/professional/support/page.tsx
+++ b/app/(pages)/professional/support/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import { toast } from "sonner";
 import { Loader2, LifeBuoy, CalendarClock, MessageCircle, Send, Plus } from "lucide-react";
@@ -101,15 +101,19 @@ function TicketsTab() {
   const [description, setDescription] = useState("");
   const [saving, setSaving] = useState(false);
   const [replyDraft, setReplyDraft] = useState<Record<string, string>>({});
+  const [replySending, setReplySending] = useState<Record<string, boolean>>({});
 
-  const load = () =>
-    proListMyTickets()
-      .then(setItems)
-      .catch((e) => toast.error(e instanceof Error ? e.message : "Failed to load tickets"));
+  const load = useCallback(
+    () =>
+      proListMyTickets()
+        .then(setItems)
+        .catch((e) => toast.error(e instanceof Error ? e.message : "Failed to load tickets")),
+    []
+  );
 
   useEffect(() => {
     load();
-  }, []);
+  }, [load]);
 
   const submit = async () => {
     if (!subject.trim() || !description.trim()) {
@@ -131,8 +135,10 @@ function TicketsTab() {
   };
 
   const sendReply = async (id: string) => {
+    if (replySending[id]) return;
     const body = replyDraft[id]?.trim();
     if (!body) return;
+    setReplySending((s) => ({ ...s, [id]: true }));
     try {
       await proReplyTicket(id, body);
       setReplyDraft((d) => ({ ...d, [id]: "" }));
@@ -140,6 +146,8 @@ function TicketsTab() {
       load();
     } catch (e) {
       toast.error(e instanceof Error ? e.message : "Failed to reply");
+    } finally {
+      setReplySending((s) => ({ ...s, [id]: false }));
     }
   };
 
@@ -213,14 +221,16 @@ function TicketsTab() {
                       <input
                         value={replyDraft[t._id] || ""}
                         onChange={(e) => setReplyDraft((d) => ({ ...d, [t._id]: e.target.value }))}
+                        disabled={Boolean(replySending[t._id])}
                         placeholder="Reply…"
-                        className="flex-1 rounded-xl border border-indigo-200 bg-white/60 px-3 py-1.5 text-sm outline-none focus:border-indigo-400 focus:bg-white focus:ring-2 focus:ring-indigo-200"
+                        className="flex-1 rounded-xl border border-indigo-200 bg-white/60 px-3 py-1.5 text-sm outline-none focus:border-indigo-400 focus:bg-white focus:ring-2 focus:ring-indigo-200 disabled:opacity-50"
                       />
                       <button
                         onClick={() => sendReply(t._id)}
-                        className="inline-flex items-center gap-1 rounded-xl bg-indigo-500 px-3 py-1.5 text-sm font-medium text-white hover:bg-indigo-600"
+                        disabled={Boolean(replySending[t._id]) || !replyDraft[t._id]?.trim()}
+                        className="inline-flex items-center gap-1 rounded-xl bg-indigo-500 px-3 py-1.5 text-sm font-medium text-white hover:bg-indigo-600 disabled:opacity-50 disabled:cursor-not-allowed"
                       >
-                        <Send size={12} /> Send
+                        {replySending[t._id] ? <Loader2 className="animate-spin" size={12} /> : <Send size={12} />} Send
                       </button>
                     </div>
                   )}
@@ -241,14 +251,17 @@ function MeetingsTab() {
   const [durationMinutes, setDurationMinutes] = useState(30);
   const [saving, setSaving] = useState(false);
 
-  const load = () =>
-    proListMyMeetingRequests()
-      .then(setItems)
-      .catch((e) => toast.error(e instanceof Error ? e.message : "Failed to load requests"));
+  const load = useCallback(
+    () =>
+      proListMyMeetingRequests()
+        .then(setItems)
+        .catch((e) => toast.error(e instanceof Error ? e.message : "Failed to load requests")),
+    []
+  );
 
   useEffect(() => {
     load();
-  }, []);
+  }, [load]);
 
   const submit = async () => {
     if (!topic.trim() || !preferredTimes.trim()) {

--- a/app/(pages)/professional/support/page.tsx
+++ b/app/(pages)/professional/support/page.tsx
@@ -50,31 +50,63 @@ export default function ProfessionalSupportPage() {
           </div>
         </div>
 
-        <div className="mt-6 flex flex-wrap gap-2">
-          <TabButton active={tab === "ticket"} onClick={() => setTab("ticket")} icon={<LifeBuoy size={14} />}>
+        <div role="tablist" aria-label="Support sections" className="mt-6 flex flex-wrap gap-2">
+          <TabButton
+            id="ticket-tab"
+            controls="ticket-panel"
+            active={tab === "ticket"}
+            onClick={() => setTab("ticket")}
+            icon={<LifeBuoy size={14} />}
+          >
             Create ticket
           </TabButton>
-          <TabButton active={tab === "meeting"} onClick={() => setTab("meeting")} icon={<CalendarClock size={14} />}>
+          <TabButton
+            id="meeting-tab"
+            controls="meeting-panel"
+            active={tab === "meeting"}
+            onClick={() => setTab("meeting")}
+            icon={<CalendarClock size={14} />}
+          >
             Plan a meeting
           </TabButton>
-          <TabButton active={tab === "chat"} onClick={() => setTab("chat")} icon={<MessageCircle size={14} />}>
+          <TabButton
+            id="chat-tab"
+            controls="chat-panel"
+            active={tab === "chat"}
+            onClick={() => setTab("chat")}
+            icon={<MessageCircle size={14} />}
+          >
             Chat
           </TabButton>
         </div>
 
-        <div className="mt-6">
-          {tab === "ticket" && <TicketsTab />}
-          {tab === "meeting" && <MeetingsTab />}
-          {tab === "chat" && <ChatPlaceholder />}
-        </div>
+        {tab === "ticket" && (
+          <div role="tabpanel" id="ticket-panel" aria-labelledby="ticket-tab" className="mt-6">
+            <TicketsTab />
+          </div>
+        )}
+        {tab === "meeting" && (
+          <div role="tabpanel" id="meeting-panel" aria-labelledby="meeting-tab" className="mt-6">
+            <MeetingsTab />
+          </div>
+        )}
+        {tab === "chat" && (
+          <div role="tabpanel" id="chat-panel" aria-labelledby="chat-tab" className="mt-6">
+            <ChatPlaceholder />
+          </div>
+        )}
       </div>
     </div>
   );
 }
 
-function TabButton({ children, active, onClick, icon }: { children: React.ReactNode; active: boolean; onClick: () => void; icon?: React.ReactNode }) {
+function TabButton({ children, active, onClick, icon, id, controls }: { children: React.ReactNode; active: boolean; onClick: () => void; icon?: React.ReactNode; id?: string; controls?: string }) {
   return (
     <button
+      id={id}
+      role="tab"
+      aria-selected={active}
+      aria-controls={controls}
       onClick={onClick}
       className={cn(
         "inline-flex items-center gap-2 rounded-xl border px-4 py-2 text-sm font-medium transition",

--- a/app/(pages)/professional/support/page.tsx
+++ b/app/(pages)/professional/support/page.tsx
@@ -106,9 +106,9 @@ function TicketsTab() {
   const load = useCallback(
     () =>
       proListMyTickets()
-        .then(setItems)
+        .then((next) => setItems(next))
         .catch((e) => {
-          setItems([]);
+          setItems((prev) => (prev === null ? [] : prev));
           toast.error(e instanceof Error ? e.message : "Failed to load tickets");
         }),
     []
@@ -260,9 +260,9 @@ function MeetingsTab() {
   const load = useCallback(
     () =>
       proListMyMeetingRequests()
-        .then(setItems)
+        .then((next) => setItems(next))
         .catch((e) => {
-          setItems([]);
+          setItems((prev) => (prev === null ? [] : prev));
           toast.error(e instanceof Error ? e.message : "Failed to load requests");
         }),
     []

--- a/app/(pages)/professional/support/page.tsx
+++ b/app/(pages)/professional/support/page.tsx
@@ -25,8 +25,10 @@ export default function ProfessionalSupportPage() {
 
   useEffect(() => {
     if (loading) return;
-    if (!isAuthenticated || user?.role !== "professional") {
+    if (!isAuthenticated) {
       router.replace("/login?redirect=/professional/support");
+    } else if (user?.role !== "professional") {
+      router.replace("/dashboard");
     }
   }, [user, isAuthenticated, loading, router]);
 

--- a/app/(pages)/projects/[id]/page.tsx
+++ b/app/(pages)/projects/[id]/page.tsx
@@ -311,7 +311,7 @@ export default function ProjectDetailPage() {
   const [reviewRatingFilter, setReviewRatingFilter] = useState<number | null>(null);
   const [reviewPage, setReviewPage] = useState(1);
   const [reviewTotalPages, setReviewTotalPages] = useState(1);
-  const [initialFavorited, setInitialFavorited] = useState(false);
+  const [initialFavorited, setInitialFavorited] = useState<boolean | null>(null);
   const { customerPrice } = useCommissionRate();
 
   const projectId = params.id as string;
@@ -332,8 +332,13 @@ export default function ProjectDetailPage() {
 
   useEffect(() => {
     // Reset on projectId change so a stale favorited flag from the previous project can't leak
-    setInitialFavorited(false);
-    if (!projectId || !isAuthenticated || user?.role !== 'customer') return;
+    setInitialFavorited(null);
+    if (!projectId) return;
+    // Non-customers can't favorite; unblock render immediately with a concrete value
+    if (!isAuthenticated || user?.role !== 'customer') {
+      setInitialFavorited(false);
+      return;
+    }
     let cancelled = false;
     (async () => {
       try {
@@ -347,11 +352,15 @@ export default function ProjectDetailPage() {
           }
         );
         const json = await res.json();
-        if (!cancelled && res.ok && json?.success) {
-          setInitialFavorited(Boolean(json.data?.favorited?.[projectId]));
+        if (!cancelled) {
+          if (res.ok && json?.success) {
+            setInitialFavorited(Boolean(json.data?.favorited?.[projectId]));
+          } else {
+            setInitialFavorited(false);
+          }
         }
       } catch {
-        // non-critical
+        if (!cancelled) setInitialFavorited(false);
       }
     })();
     return () => {
@@ -744,14 +753,16 @@ export default function ProjectDetailPage() {
                       )}
                     </CardDescription>
                   </div>
-                  <FavoriteButton
-                    key={project._id}
-                    targetType='project'
-                    targetId={project._id}
-                    initialFavorited={initialFavorited}
-                    size='md'
-                    stopPropagation={false}
-                  />
+                  {initialFavorited !== null && (
+                    <FavoriteButton
+                      key={project._id}
+                      targetType='project'
+                      targetId={project._id}
+                      initialFavorited={initialFavorited}
+                      size='md'
+                      stopPropagation={false}
+                    />
+                  )}
                 </div>
               </CardHeader>
               <CardContent className='space-y-4'>

--- a/app/(pages)/projects/[id]/page.tsx
+++ b/app/(pages)/projects/[id]/page.tsx
@@ -331,6 +331,8 @@ export default function ProjectDetailPage() {
   }, [projectId]);
 
   useEffect(() => {
+    // Reset on projectId change so a stale favorited flag from the previous project can't leak
+    setInitialFavorited(false);
     if (!projectId || !isAuthenticated || user?.role !== 'customer') return;
     let cancelled = false;
     (async () => {
@@ -743,6 +745,7 @@ export default function ProjectDetailPage() {
                     </CardDescription>
                   </div>
                   <FavoriteButton
+                    key={project._id}
                     targetType='project'
                     targetId={project._id}
                     initialFavorited={initialFavorited}

--- a/app/(pages)/projects/[id]/page.tsx
+++ b/app/(pages)/projects/[id]/page.tsx
@@ -40,6 +40,7 @@ import { formatCurrency } from '@/lib/formatters';
 import Image from 'next/image';
 import ProjectBookingForm from '@/components/project/ProjectBookingForm';
 import SubprojectComparisonTable from '@/components/project/SubprojectComparisonTable';
+import FavoriteButton from '@/components/favorites/FavoriteButton';
 import {
   formatPriceModelLabel,
   getCertificateGradient,
@@ -148,7 +149,7 @@ type ProvidedByCardProps = {
 
 const ProvidedByCard = ({ pro, stats }: ProvidedByCardProps) => {
   const proName =
-    pro.businessInfo?.companyName || pro.name || pro.username || 'Professional';
+    pro.name || pro.businessInfo?.companyName || pro.username || 'Professional';
   const proLocation = [pro.businessInfo?.city, pro.businessInfo?.country]
     .filter(Boolean)
     .join(', ');
@@ -310,6 +311,7 @@ export default function ProjectDetailPage() {
   const [reviewRatingFilter, setReviewRatingFilter] = useState<number | null>(null);
   const [reviewPage, setReviewPage] = useState(1);
   const [reviewTotalPages, setReviewTotalPages] = useState(1);
+  const [initialFavorited, setInitialFavorited] = useState(false);
   const { customerPrice } = useCommissionRate();
 
   const projectId = params.id as string;
@@ -327,6 +329,33 @@ export default function ProjectDetailPage() {
   useEffect(() => {
     fetchProject();
   }, [projectId]);
+
+  useEffect(() => {
+    if (!projectId || !isAuthenticated || user?.role !== 'customer') return;
+    let cancelled = false;
+    (async () => {
+      try {
+        const { authFetch } = await import('@/lib/utils');
+        const res = await authFetch(
+          `${process.env.NEXT_PUBLIC_BACKEND_URL}/api/favorites/status`,
+          {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ targetType: 'project', targetIds: [projectId] }),
+          }
+        );
+        const json = await res.json();
+        if (!cancelled && res.ok && json?.success) {
+          setInitialFavorited(Boolean(json.data?.favorited?.[projectId]));
+        }
+      } catch {
+        // non-critical
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [projectId, isAuthenticated, user?.role]);
 
   useEffect(() => {
     if (!projectId) return;
@@ -693,7 +722,7 @@ export default function ProjectDetailPage() {
             {/* Project Details */}
             <Card>
               <CardHeader>
-                <div className='flex items-start justify-between'>
+                <div className='flex items-start justify-between gap-3'>
                   <div>
                     <CardTitle className='text-3xl mb-2'>
                       {project.title}
@@ -713,6 +742,13 @@ export default function ProjectDetailPage() {
                       )}
                     </CardDescription>
                   </div>
+                  <FavoriteButton
+                    targetType='project'
+                    targetId={project._id}
+                    initialFavorited={initialFavorited}
+                    size='md'
+                    stopPropagation={false}
+                  />
                 </div>
               </CardHeader>
               <CardContent className='space-y-4'>

--- a/app/(pages)/services/[serviceId]/page.tsx
+++ b/app/(pages)/services/[serviceId]/page.tsx
@@ -13,6 +13,18 @@ import ProfessionalFilters from '@/components/ProfessionalFilters';
 import JsonLd from '@/components/seo/JsonLd';
 import { breadcrumbSchema, serviceSchema } from '@/lib/seo/jsonLd';
 import { buildMetadata } from '@/lib/seo/metadata';
+import { publicGetCms } from '@/lib/cms';
+import RichTextRenderer from '@/components/cms/RichTextRenderer';
+
+export const dynamic = "force-dynamic";
+
+async function fetchServiceLanding(serviceId: string) {
+  try {
+    return await publicGetCms("landing", serviceId);
+  } catch {
+    return null;
+  }
+}
 
 type Props = {
   params: Promise<{
@@ -35,6 +47,16 @@ function findServiceMeta(serviceId: string) {
 
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const { serviceId } = await params;
+  const landing = await fetchServiceLanding(serviceId);
+  if (landing) {
+    return buildMetadata({
+      title: landing.seo?.titleTag || landing.title,
+      description: landing.seo?.metaDescription || landing.excerpt,
+      path: landing.seo?.canonical || `/services/${encodeURIComponent(serviceId)}`,
+      image: landing.seo?.ogImage || landing.coverImage,
+      noindex: landing.seo?.noindex,
+    });
+  }
   const meta = findServiceMeta(serviceId);
   if (!meta) notFound();
   const description = meta.description || `Find verified professionals for ${meta.name.toLowerCase()} on Fixera.`;
@@ -92,7 +114,54 @@ export default async function Page({ params }: Props) {
 
   const { serviceId } = await params;
 
+  const landing = await fetchServiceLanding(serviceId);
   const meta = findServiceMeta(serviceId);
+
+  if (landing) {
+    const safePath = `/services/${encodeURIComponent(serviceId)}`;
+    return (
+      <div className="bg-white">
+        <JsonLd
+          data={breadcrumbSchema([
+            { name: 'Home', path: '/' },
+            { name: 'Services', path: '/services' },
+            { name: landing.title, path: safePath },
+          ])}
+        />
+        {landing.coverImage && (
+          <div className="relative h-72 md:h-96 w-full">
+            <Image src={landing.coverImage} alt={landing.title} fill className="object-cover" priority unoptimized />
+            <div className="absolute inset-0 bg-gradient-to-t from-black/60 to-black/20" />
+            <div className="absolute inset-0 flex flex-col justify-end">
+              <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 w-full pb-12">
+                <div className="flex items-center text-sm text-white mb-2">
+                  <Link href="/" className="hover:underline">Home</Link>
+                  <ChevronRight className="w-4 h-4 mx-1" />
+                  <Link href="/services" className="hover:underline">Services</Link>
+                </div>
+                <h1 className="text-4xl md:text-6xl font-bold text-white tracking-tight">{landing.title}</h1>
+              </div>
+            </div>
+          </div>
+        )}
+        {!landing.coverImage && (
+          <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 w-full pt-28 pb-6">
+            <div className="flex items-center text-sm text-gray-500 mb-2">
+              <Link href="/" className="hover:underline">Home</Link>
+              <ChevronRight className="w-4 h-4 mx-1" />
+              <Link href="/services" className="hover:underline">Services</Link>
+            </div>
+            <h1 className="text-4xl md:text-5xl font-bold text-gray-900 tracking-tight">{landing.title}</h1>
+            {landing.excerpt && <p className="mt-3 text-lg text-gray-600 max-w-3xl">{landing.excerpt}</p>}
+          </div>
+        )}
+        <main className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
+          <RichTextRenderer html={landing.body} />
+        </main>
+      </div>
+    );
+  }
+
   if (!meta) notFound();
   const serviceName = meta.name;
   const safePath = `/services/${encodeURIComponent(serviceId)}`;

--- a/app/(pages)/services/[serviceId]/page.tsx
+++ b/app/(pages)/services/[serviceId]/page.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { cache } from 'react';
 import Link from 'next/link';
 import Image from 'next/image';
 import { notFound } from 'next/navigation';
@@ -18,13 +18,13 @@ import RichTextRenderer from '@/components/cms/RichTextRenderer';
 
 export const dynamic = "force-dynamic";
 
-async function fetchServiceLanding(serviceId: string) {
+const fetchServiceLanding = cache(async (serviceId: string) => {
   try {
     return await publicGetCms("landing", serviceId);
   } catch {
     return null;
   }
-}
+});
 
 type Props = {
   params: Promise<{

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import Link from 'next/link'
-import { Hammer, Facebook, Twitter, Instagram, Linkedin, Youtube } from 'lucide-react'
+import { Hammer, Facebook, Twitter, Instagram, Linkedin, Youtube, Music2 } from 'lucide-react'
 import { footerSections } from '@/data/content'
 import { publicListPolicyLinks, PolicyLink } from '@/lib/cms'
 import { publicGetSiteSettings, SiteSettings } from '@/lib/siteSettings'
@@ -17,6 +17,7 @@ const SOCIAL_DEFS: Array<{ key: keyof NonNullable<SiteSettings['socialLinks']>; 
   { key: 'twitter', name: 'Twitter', icon: Twitter },
   { key: 'instagram', name: 'Instagram', icon: Instagram },
   { key: 'linkedin', name: 'LinkedIn', icon: Linkedin },
+  { key: 'tiktok', name: 'TikTok', icon: Music2 },
   { key: 'youtube', name: 'YouTube', icon: Youtube },
 ]
 
@@ -91,12 +92,11 @@ export default async function Footer() {
           <div className="mt-6 flex flex-wrap justify-center sm:justify-start gap-x-6 gap-y-2">
             {LEGAL_SLOTS.map((slot) => {
               const match = bySlug[slot.slug]
-              return match ? (
+              if (!match) return null
+              return (
                 <Link key={slot.slug} href={match.path} className="text-sm text-gray-400 hover:text-white hover:underline">
                   {slot.label}
                 </Link>
-              ) : (
-                <span key={slot.slug} className="text-sm text-gray-500">{slot.label}</span>
               )
             })}
           </div>

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -1,27 +1,49 @@
-'use client'
-
 import React from 'react'
 import Link from 'next/link'
-import { Hammer } from 'lucide-react'
-import { footerSections, socialLinks, legalLinks } from '@/data/content'
+import { Hammer, Facebook, Twitter, Instagram, Linkedin, Youtube } from 'lucide-react'
+import { footerSections } from '@/data/content'
+import { publicListPolicyLinks, PolicyLink } from '@/lib/cms'
+import { publicGetSiteSettings, SiteSettings } from '@/lib/siteSettings'
 
-const FooterLinkColumn = ({ title, links }: { title: string, links: {name: string, href: string}[] }) => (
-    <div>
-        <h4 className="text-lg font-semibold text-white mb-6">{title}</h4>
-        <ul className="space-y-4">
-            {links.map((link) => (
-                <li key={link.name}>
-                    <Link href={link.href} className="text-gray-300 hover:text-white hover:underline transition-colors">
-                        {link.name}
-                    </Link>
-                </li>
-            ))}
-        </ul>
-    </div>
-);
+const LEGAL_SLOTS: Array<{ slug: string; label: string }> = [
+  { slug: 'privacy-policy', label: 'Privacy Policy' },
+  { slug: 'terms-of-service', label: 'Terms of Service' },
+  { slug: 'cookie-policy', label: 'Cookie Policy' },
+  { slug: 'gdpr-compliance', label: 'GDPR Compliance' },
+]
 
-const Footer = () => {
+const SOCIAL_DEFS: Array<{ key: keyof NonNullable<SiteSettings['socialLinks']>; name: string; icon: React.ComponentType<{ className?: string }> }> = [
+  { key: 'facebook', name: 'Facebook', icon: Facebook },
+  { key: 'twitter', name: 'Twitter', icon: Twitter },
+  { key: 'instagram', name: 'Instagram', icon: Instagram },
+  { key: 'linkedin', name: 'LinkedIn', icon: Linkedin },
+  { key: 'youtube', name: 'YouTube', icon: Youtube },
+]
+
+const FooterLinkColumn = ({ title, links }: { title: string; links: { name: string; href: string }[] }) => (
+  <div>
+    <h4 className="text-lg font-semibold text-white mb-6">{title}</h4>
+    <ul className="space-y-4">
+      {links.map((link) => (
+        <li key={link.name}>
+          <Link href={link.href} className="text-gray-300 hover:text-white hover:underline transition-colors">
+            {link.name}
+          </Link>
+        </li>
+      ))}
+    </ul>
+  </div>
+)
+
+export default async function Footer() {
   const currentYear = new Date().getFullYear()
+
+  const [policies, settings] = await Promise.all([
+    publicListPolicyLinks().catch(() => [] as PolicyLink[]),
+    publicGetSiteSettings().catch(() => ({ socialLinks: {} } as SiteSettings)),
+  ])
+
+  const bySlug: Record<string, PolicyLink> = Object.fromEntries(policies.map((p) => [p.slug, p]))
 
   return (
     <footer className="bg-gray-900 ">
@@ -40,7 +62,7 @@ const Footer = () => {
               Fixera is a trusted platform connecting customers with verified professionals for any property service. From minor repairs to major renovations, we make it simple to get the job done with quality and security guaranteed.
             </p>
           </div>
-          
+
           {footerSections.map((section) => (
             <FooterLinkColumn key={section.title} title={section.title} links={section.links} />
           ))}
@@ -54,28 +76,32 @@ const Footer = () => {
               © {currentYear} Fixera. All rights reserved.
             </p>
             <div className="flex items-center space-x-6">
-              {socialLinks.map((link) => {
-                const Icon = link.icon;
+              {SOCIAL_DEFS.map(({ key, name, icon: Icon }) => {
+                const href = settings?.socialLinks?.[key]
+                if (!href) return null
                 return (
-                  <a key={link.name} href={link.href} target="_blank" rel="noopener noreferrer" className="text-gray-400 hover:text-white transition-colors">
+                  <a key={name} href={href} target="_blank" rel="noopener noreferrer" className="text-gray-400 hover:text-white transition-colors">
                     <Icon className="w-6 h-6" />
-                    <span className="sr-only">{link.name}</span>
+                    <span className="sr-only">{name}</span>
                   </a>
-                );
+                )
               })}
             </div>
           </div>
-           <div className="mt-6 flex flex-wrap justify-center sm:justify-start gap-x-6 gap-y-2">
-              {legalLinks.map((link) => (
-                <Link key={link.name} href={link.href} className="text-sm text-gray-400 hover:text-white hover:underline">
-                  {link.name}
+          <div className="mt-6 flex flex-wrap justify-center sm:justify-start gap-x-6 gap-y-2">
+            {LEGAL_SLOTS.map((slot) => {
+              const match = bySlug[slot.slug]
+              return match ? (
+                <Link key={slot.slug} href={match.path} className="text-sm text-gray-400 hover:text-white hover:underline">
+                  {slot.label}
                 </Link>
-              ))}
-            </div>
+              ) : (
+                <span key={slot.slug} className="text-sm text-gray-500">{slot.label}</span>
+              )
+            })}
+          </div>
         </div>
       </div>
     </footer>
   )
 }
-
-export default Footer

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -16,6 +16,8 @@ const LEGAL_SLOTS: Array<{ slug: string; label: string }> = [
 const MANDATORY_FALLBACKS: PolicyLink[] = [
   { slug: 'privacy-policy', title: 'Privacy Policy', path: '/privacy-policy' },
   { slug: 'terms-of-service', title: 'Terms of Service', path: '/pages/terms-of-service' },
+  { slug: 'cookie-policy', title: 'Cookie Policy', path: '/pages/cookie-policy' },
+  { slug: 'gdpr-compliance', title: 'GDPR Compliance', path: '/pages/gdpr-compliance' },
 ]
 
 function isSafeHttpUrl(href: string): boolean {

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -12,6 +12,21 @@ const LEGAL_SLOTS: Array<{ slug: string; label: string }> = [
   { slug: 'gdpr-compliance', label: 'GDPR Compliance' },
 ]
 
+// Mandatory fallbacks so transient fetch errors don't drop required legal links
+const MANDATORY_FALLBACKS: PolicyLink[] = [
+  { slug: 'privacy-policy', title: 'Privacy Policy', path: '/privacy-policy' },
+  { slug: 'terms-of-service', title: 'Terms of Service', path: '/pages/terms-of-service' },
+]
+
+function isSafeHttpUrl(href: string): boolean {
+  try {
+    const parsed = new URL(href)
+    return parsed.protocol === 'http:' || parsed.protocol === 'https:'
+  } catch {
+    return false
+  }
+}
+
 const SOCIAL_DEFS: Array<{ key: keyof NonNullable<SiteSettings['socialLinks']>; name: string; icon: React.ComponentType<{ className?: string }> }> = [
   { key: 'facebook', name: 'Facebook', icon: Facebook },
   { key: 'twitter', name: 'Twitter', icon: Twitter },
@@ -44,7 +59,10 @@ export default async function Footer() {
     publicGetSiteSettings().catch(() => ({ socialLinks: {} } as SiteSettings)),
   ])
 
-  const bySlug: Record<string, PolicyLink> = Object.fromEntries(policies.map((p) => [p.slug, p]))
+  // Merge: fetched wins on duplicate slug, fallbacks fill gaps for mandatory links
+  const bySlug: Record<string, PolicyLink> = Object.fromEntries(
+    [...MANDATORY_FALLBACKS, ...policies].map((p) => [p.slug, p])
+  )
 
   return (
     <footer className="bg-gray-900 ">
@@ -79,7 +97,7 @@ export default async function Footer() {
             <div className="flex items-center space-x-6">
               {SOCIAL_DEFS.map(({ key, name, icon: Icon }) => {
                 const href = settings?.socialLinks?.[key]
-                if (!href) return null
+                if (!href || !isSafeHttpUrl(href)) return null
                 return (
                   <a key={name} href={href} target="_blank" rel="noopener noreferrer" className="text-gray-400 hover:text-white transition-colors">
                     <Icon className="w-6 h-6" />

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -4,7 +4,7 @@ import React, { useState, useEffect } from "react";
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
-import { Menu, X, Hammer, User, LogOut, MessageSquare } from "lucide-react";
+import { Menu, X, Hammer, User, LogOut, MessageSquare, LifeBuoy, Heart } from "lucide-react";
 import { useAuth } from "@/contexts/AuthContext";
 import { useUnreadCount } from "@/hooks/useUnreadCount";
 import {
@@ -88,6 +88,15 @@ const Navbar = () => {
                 <>
                   {isAuthenticated ? (
                     <>
+                      {user?.role === "customer" && (
+                        <Link
+                          href="/dashboard/favorites"
+                          className="relative inline-flex items-center justify-center h-8 w-8 rounded-full text-gray-600 hover:text-pink-600 hover:bg-gray-100 transition-colors"
+                          aria-label="Favorites"
+                        >
+                          <Heart className="h-5 w-5" />
+                        </Link>
+                      )}
                       {showChatIcon && (
                         <Link
                           href="/chat"
@@ -146,6 +155,14 @@ const Navbar = () => {
                               <Link href="/dashboard/benefits">
                                 <User className="mr-2 h-4 w-4" />
                                 <span>Benefits Program</span>
+                              </Link>
+                            </DropdownMenuItem>
+                          )}
+                          {user?.role === "professional" && (
+                            <DropdownMenuItem asChild>
+                              <Link href="/professional/support">
+                                <LifeBuoy className="mr-2 h-4 w-4" />
+                                <span>Professional Support</span>
                               </Link>
                             </DropdownMenuItem>
                           )}
@@ -216,6 +233,19 @@ const Navbar = () => {
               {link.name}
             </Link>
           ))}
+          {isAuthenticated && user?.role === "customer" && (
+            <>
+              <hr className="my-2" />
+              <Link
+                href="/dashboard/favorites"
+                className="flex items-center gap-2 p-2 text-lg font-medium text-gray-800 hover:text-pink-600 rounded-lg hover:bg-gray-50 transition-colors"
+                onClick={() => setIsMenuOpen(false)}
+              >
+                <Heart className="h-5 w-5" />
+                Favorites
+              </Link>
+            </>
+          )}
           {showChatIcon && (
             <>
               <hr className="my-2" />
@@ -270,6 +300,11 @@ const Navbar = () => {
                   {(user?.role === "customer" || user?.role === "professional") && (
                     <Button asChild variant="outline" className="w-full">
                       <Link href="/dashboard/benefits">Benefits Program</Link>
+                    </Button>
+                  )}
+                  {user?.role === "professional" && (
+                    <Button asChild variant="outline" className="w-full">
+                      <Link href="/professional/support">Professional Support</Link>
                     </Button>
                   )}
                   <Button onClick={logout} variant="outline" className="w-full">

--- a/components/cms/BlogCard.tsx
+++ b/components/cms/BlogCard.tsx
@@ -1,6 +1,6 @@
 import Link from "next/link";
 import { ArrowUpRight, Calendar } from "lucide-react";
-import { CmsContent } from "@/lib/cms";
+import { CmsContent, cmsAuthorName } from "@/lib/cms";
 
 interface Props {
   item: CmsContent;
@@ -8,7 +8,7 @@ interface Props {
 }
 
 export default function BlogCard({ item, basePath }: Props) {
-  const authorName = typeof item.author === "object" && item.author ? item.author.name : undefined;
+  const authorName = cmsAuthorName(item);
   const date = item.publishedAt || item.updatedAt;
 
   return (

--- a/components/cms/CmsContentForm.tsx
+++ b/components/cms/CmsContentForm.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
 import { toast } from "sonner";
-import { ArrowLeft, FileText, Loader2, Save, Send, Tag, Trash2, X } from "lucide-react";
+import { ArrowLeft, ExternalLink, FileText, Loader2, Save, Send, Tag, Trash2, X } from "lucide-react";
 import {
   adminCreateCms,
   adminDeleteCms,
@@ -42,6 +42,7 @@ const EMPTY: Partial<CmsContent> = {
   coverImage: "",
   category: "",
   tags: [],
+  authorOverride: "",
   status: "draft",
   seo: {},
 };
@@ -134,6 +135,7 @@ export default function CmsContentForm({ mode, initial, lockedType }: Props) {
         coverImage: form.coverImage || undefined,
         category: isFaq ? form.category : undefined,
         tags: hasTags ? form.tags || [] : [],
+        authorOverride: hasTags ? (form.authorOverride || "").trim() : undefined,
         status,
         seo: form.seo || {},
       };
@@ -187,6 +189,25 @@ export default function CmsContentForm({ mode, initial, lockedType }: Props) {
             <ArrowLeft size={16} /> Back to content
           </button>
           <div className="flex items-center gap-2">
+            {mode === "edit" && publicPreviewPath && (
+              form.status === "published" ? (
+                <a
+                  href={publicPreviewPath}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex items-center gap-2 rounded-xl border border-pink-200 bg-white px-4 py-2 text-sm font-medium text-rose-700 transition hover:bg-rose-50"
+                >
+                  <ExternalLink size={14} /> View live
+                </a>
+              ) : (
+                <span
+                  title="Publish first to view live"
+                  className="inline-flex cursor-not-allowed items-center gap-2 rounded-xl border border-pink-200 bg-white/70 px-4 py-2 text-sm font-medium text-rose-400"
+                >
+                  <ExternalLink size={14} /> View live
+                </span>
+              )
+            )}
             {mode === "edit" && (
               <button
                 onClick={remove}
@@ -337,6 +358,22 @@ export default function CmsContentForm({ mode, initial, lockedType }: Props) {
               />
             </div>
           </GradientCard>
+
+          {hasTags && (
+            <GradientCard>
+              <div className="p-6 space-y-2">
+                <h3 className="text-sm font-semibold uppercase tracking-wide text-rose-700">Writer name</h3>
+                <input
+                  value={form.authorOverride || ""}
+                  onChange={(e) => update({ authorOverride: e.target.value })}
+                  placeholder="Defaults to your admin name"
+                  maxLength={120}
+                  className="w-full rounded-xl border border-pink-200 bg-white/60 px-4 py-2 text-sm outline-none transition focus:border-rose-400 focus:bg-white focus:ring-2 focus:ring-rose-200"
+                />
+                <p className="text-[11px] text-rose-400">Shown as the author on blog/news cards and detail pages.</p>
+              </div>
+            </GradientCard>
+          )}
 
           {isFaq && (
             <GradientCard>

--- a/components/cms/FaqAccordion.tsx
+++ b/components/cms/FaqAccordion.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useId, useState } from "react";
+import { useEffect, useId, useState } from "react";
 import { ChevronDown } from "lucide-react";
 import { cn } from "@/lib/utils";
 import RichTextRenderer from "./RichTextRenderer";
@@ -39,6 +39,17 @@ function FaqItem({ anchor, title, body }: { anchor: string; title: string; body:
   const reactId = useId();
   const buttonId = `faq-btn-${reactId}`;
   const panelId = `faq-panel-${reactId}`;
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const check = () => {
+      if (window.location.hash === `#${anchor}`) setOpen(true);
+    };
+    check();
+    window.addEventListener("hashchange", check);
+    return () => window.removeEventListener("hashchange", check);
+  }, [anchor]);
+
   return (
     <div id={anchor} className="scroll-mt-24 rounded-2xl bg-gradient-to-br from-rose-100 via-pink-100 to-orange-100 p-[1.5px] transition hover:from-rose-200 hover:via-pink-200 hover:to-orange-200 hover:shadow-md hover:shadow-rose-100">
       <div className="rounded-[calc(1rem-1.5px)] bg-white">

--- a/components/cms/FaqAccordion.tsx
+++ b/components/cms/FaqAccordion.tsx
@@ -25,7 +25,7 @@ export default function FaqAccordion({ groups }: Props) {
           </div>
           <div className="space-y-3">
             {group.items.map((item) => (
-              <FaqItem key={item._id} title={item.title} body={item.body} />
+              <FaqItem key={item._id} anchor={item.slug} title={item.title} body={item.body} />
             ))}
           </div>
         </section>
@@ -34,13 +34,13 @@ export default function FaqAccordion({ groups }: Props) {
   );
 }
 
-function FaqItem({ title, body }: { title: string; body: string }) {
+function FaqItem({ anchor, title, body }: { anchor: string; title: string; body: string }) {
   const [open, setOpen] = useState(false);
   const reactId = useId();
   const buttonId = `faq-btn-${reactId}`;
   const panelId = `faq-panel-${reactId}`;
   return (
-    <div className="rounded-2xl bg-gradient-to-br from-rose-100 via-pink-100 to-orange-100 p-[1.5px] transition hover:from-rose-200 hover:via-pink-200 hover:to-orange-200 hover:shadow-md hover:shadow-rose-100">
+    <div id={anchor} className="scroll-mt-24 rounded-2xl bg-gradient-to-br from-rose-100 via-pink-100 to-orange-100 p-[1.5px] transition hover:from-rose-200 hover:via-pink-200 hover:to-orange-200 hover:shadow-md hover:shadow-rose-100">
       <div className="rounded-[calc(1rem-1.5px)] bg-white">
         <button
           id={buttonId}

--- a/data/content.ts
+++ b/data/content.ts
@@ -1,5 +1,4 @@
 import { iconMapData } from './icons';
-import { Facebook, Twitter, Instagram, Linkedin } from 'lucide-react';
 
 export const iconMap = iconMapData;
 
@@ -371,8 +370,6 @@ export const footerSections = [
       links: [
         { name: 'Join as Professional', href: '/join' },
         { name: 'Success Stories', href: '#professionals' },
-        { name: 'Business Resources', href: '#' },
-        { name: 'Professional Support', href: '#' },
       ]
     },
     {
@@ -392,19 +389,6 @@ export const footerContact = {
     email: 'support@fixera.com',
 };
 
-export const socialLinks = [
-    { name: 'Facebook', icon: Facebook, href: '#' },
-    { name: 'Twitter', icon: Twitter, href: '#' },
-    { name: 'Instagram', icon: Instagram, href: '#' },
-    { name: 'Linkedin', icon: Linkedin, href: '#' },
-];
-
-export const legalLinks = [
-    { name: 'Privacy Policy', href: '/privacy-policy' },
-    { name: 'Terms of Service', href: '/pages/terms-of-service' },
-    { name: 'Cookie Policy', href: '/pages/cookie-policy' },
-    { name: 'GDPR Compliance', href: '/pages/gdpr-compliance' },
-];
 
 
 export const subNavbarCategories = [

--- a/lib/cms.ts
+++ b/lib/cms.ts
@@ -67,6 +67,7 @@ export interface CmsUpsertPayload {
 export function cmsAuthorName(item: Pick<CmsContent, "author" | "authorOverride">): string | undefined {
   if (item.authorOverride && item.authorOverride.trim()) return item.authorOverride.trim();
   if (typeof item.author === "object" && item.author) return item.author.name;
+  if (typeof item.author === "string" && item.author.trim()) return item.author.trim();
   return undefined;
 }
 

--- a/lib/cms.ts
+++ b/lib/cms.ts
@@ -35,6 +35,7 @@ export interface CmsContent {
   tags: string[];
   status: CmsContentStatus;
   author?: { _id: string; name?: string; email?: string } | string;
+  authorOverride?: string;
   publishedAt?: string;
   seo: CmsSeo;
   relatedContent?: Array<{ _id: string; title?: string; slug?: string; type?: CmsContentType } | string>;
@@ -56,10 +57,17 @@ export interface CmsUpsertPayload {
   tags?: string[];
   status?: CmsContentStatus;
   author?: string;
+  authorOverride?: string;
   publishedAt?: string;
   seo?: CmsSeo;
   relatedContent?: string[];
   relatedServices?: string[];
+}
+
+export function cmsAuthorName(item: Pick<CmsContent, "author" | "authorOverride">): string | undefined {
+  if (item.authorOverride && item.authorOverride.trim()) return item.authorOverride.trim();
+  if (typeof item.author === "object" && item.author) return item.author.name;
+  return undefined;
 }
 
 export interface FaqCategory {
@@ -199,6 +207,22 @@ export async function publicGetFaq(): Promise<{ groups: FaqGroup[]; categories: 
   return parseJsonRequired<{ groups: FaqGroup[]; categories: FaqCategory[] }>(res);
 }
 
+export interface PolicyLink {
+  title: string;
+  slug: string;
+  path: string;
+}
+
+export async function publicListPolicyLinks(): Promise<PolicyLink[]> {
+  try {
+    const res = await fetch(`${API()}/api/public/cms/policy-links`, { cache: "no-store" });
+    const data = await parseJsonRequired<{ items: PolicyLink[] }>(res);
+    return data.items || [];
+  } catch {
+    return [];
+  }
+}
+
 export interface SitemapEntry {
   type: CmsContentType;
   slug: string;
@@ -226,8 +250,11 @@ export async function publicListSitemapEntries(
 // ---------- Utils ----------
 
 const RESERVED_POLICY_PATHS: Record<string, string> = {
-  about: "/about",
   "privacy-policy": "/privacy-policy",
+};
+
+const RESERVED_LANDING_PATHS: Record<string, string> = {
+  about: "/about",
 };
 
 export function getPublicPathForCms(type: CmsContentType, slug: string): string | null {
@@ -238,13 +265,19 @@ export function getPublicPathForCms(type: CmsContentType, slug: string): string 
     case "news":
       return `/news/${slug}`;
     case "landing":
-      return `/pages/${slug}`;
+      return RESERVED_LANDING_PATHS[slug] || `/pages/${slug}`;
     case "policy":
       return RESERVED_POLICY_PATHS[slug] || `/pages/${slug}`;
     case "faq":
+      return `/faq#${slug}`;
     default:
       return null;
   }
+}
+
+export function getLandingServicePath(slug: string): string | null {
+  if (!slug || RESERVED_LANDING_PATHS[slug]) return null;
+  return `/services/${slug}`;
 }
 
 export function getPublicSlugPrefixForCms(type: CmsContentType): string | null {

--- a/lib/cms.ts
+++ b/lib/cms.ts
@@ -66,7 +66,10 @@ export interface CmsUpsertPayload {
 
 export function cmsAuthorName(item: Pick<CmsContent, "author" | "authorOverride">): string | undefined {
   if (item.authorOverride && item.authorOverride.trim()) return item.authorOverride.trim();
-  if (typeof item.author === "object" && item.author) return item.author.name;
+  if (typeof item.author === "object" && item.author) {
+    const name = item.author.name?.trim();
+    if (name) return name;
+  }
   if (typeof item.author === "string" && item.author.trim()) return item.author.trim();
   return undefined;
 }

--- a/lib/cms.ts
+++ b/lib/cms.ts
@@ -255,11 +255,10 @@ export async function publicListSitemapEntries(
 
 const RESERVED_POLICY_PATHS: Record<string, string> = {
   "privacy-policy": "/privacy-policy",
-};
-
-const RESERVED_LANDING_PATHS: Record<string, string> = {
   about: "/about",
 };
+
+const RESERVED_LANDING_PATHS: Record<string, string> = {};
 
 export function getPublicPathForCms(type: CmsContentType, slug: string): string | null {
   if (!slug) return null;

--- a/lib/siteSettings.ts
+++ b/lib/siteSettings.ts
@@ -1,0 +1,50 @@
+import { authFetch } from "@/lib/utils";
+
+export interface SocialLinks {
+  facebook?: string;
+  twitter?: string;
+  instagram?: string;
+  linkedin?: string;
+  tiktok?: string;
+  youtube?: string;
+}
+
+export interface SiteSettings {
+  socialLinks?: SocialLinks;
+}
+
+const API = () => process.env.NEXT_PUBLIC_BACKEND_URL || "";
+
+export async function publicGetSiteSettings(): Promise<SiteSettings> {
+  try {
+    const res = await fetch(`${API()}/api/public/site-settings`, { cache: "no-store" });
+    if (!res.ok) return { socialLinks: {} };
+    const body = await res.json();
+    if (body?.success === false) return { socialLinks: {} };
+    return (body?.data as SiteSettings) || { socialLinks: {} };
+  } catch {
+    return { socialLinks: {} };
+  }
+}
+
+export async function adminGetSiteSettings(): Promise<SiteSettings> {
+  const res = await authFetch(`${API()}/api/admin/site-settings`);
+  const body = await res.json();
+  if (!res.ok || body?.success === false) {
+    throw new Error(body?.msg || `Request failed (${res.status})`);
+  }
+  return body.data as SiteSettings;
+}
+
+export async function adminUpdateSiteSettings(payload: { socialLinks?: SocialLinks }): Promise<SiteSettings> {
+  const res = await authFetch(`${API()}/api/admin/site-settings`, {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(payload),
+  });
+  const body = await res.json();
+  if (!res.ok || body?.success === false) {
+    throw new Error(body?.msg || `Request failed (${res.status})`);
+  }
+  return body.data as SiteSettings;
+}

--- a/lib/siteSettings.ts
+++ b/lib/siteSettings.ts
@@ -15,12 +15,32 @@ export interface SiteSettings {
 
 const API = () => process.env.NEXT_PUBLIC_BACKEND_URL || "";
 
+interface ApiEnvelope {
+  success?: boolean;
+  msg?: string;
+  data?: unknown;
+}
+
+async function safeParseJson(res: Response): Promise<{ body: ApiEnvelope | null; text?: string }> {
+  const contentType = res.headers.get("content-type") || "";
+  if (!contentType.includes("application/json")) {
+    const text = await res.text().catch(() => "");
+    return { body: null, text };
+  }
+  try {
+    const body = (await res.json()) as ApiEnvelope;
+    return { body };
+  } catch {
+    return { body: null };
+  }
+}
+
 export async function publicGetSiteSettings(): Promise<SiteSettings> {
   try {
     const res = await fetch(`${API()}/api/public/site-settings`, { cache: "no-store" });
     if (!res.ok) return { socialLinks: {} };
-    const body = await res.json();
-    if (body?.success === false) return { socialLinks: {} };
+    const { body } = await safeParseJson(res);
+    if (!body || body?.success === false) return { socialLinks: {} };
     return (body?.data as SiteSettings) || { socialLinks: {} };
   } catch {
     return { socialLinks: {} };
@@ -29,9 +49,13 @@ export async function publicGetSiteSettings(): Promise<SiteSettings> {
 
 export async function adminGetSiteSettings(): Promise<SiteSettings> {
   const res = await authFetch(`${API()}/api/admin/site-settings`);
-  const body = await res.json();
-  if (!res.ok || body?.success === false) {
-    throw new Error(body?.msg || `Request failed (${res.status})`);
+  const { body, text } = await safeParseJson(res);
+  if (!res.ok || !body || body?.success === false) {
+    throw new Error(
+      body?.msg ||
+        (text && text.slice(0, 200)) ||
+        `Request failed (${res.status})`
+    );
   }
   return body.data as SiteSettings;
 }
@@ -42,9 +66,13 @@ export async function adminUpdateSiteSettings(payload: { socialLinks?: SocialLin
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(payload),
   });
-  const body = await res.json();
-  if (!res.ok || body?.success === false) {
-    throw new Error(body?.msg || `Request failed (${res.status})`);
+  const { body, text } = await safeParseJson(res);
+  if (!res.ok || !body || body?.success === false) {
+    throw new Error(
+      body?.msg ||
+        (text && text.slice(0, 200)) ||
+        `Request failed (${res.status})`
+    );
   }
   return body.data as SiteSettings;
 }

--- a/lib/support.ts
+++ b/lib/support.ts
@@ -1,0 +1,121 @@
+import { authFetch } from "@/lib/utils";
+
+const API = () => process.env.NEXT_PUBLIC_BACKEND_URL || "";
+
+export type SupportTicketStatus = "open" | "in_progress" | "resolved" | "closed";
+
+export interface SupportTicketReply {
+  authorId: string;
+  authorRole: "professional" | "admin";
+  body: string;
+  createdAt: string;
+}
+
+export interface SupportTicket {
+  _id: string;
+  userId: string | { _id: string; name?: string; email?: string; role?: string };
+  subject: string;
+  description: string;
+  status: SupportTicketStatus;
+  replies: SupportTicketReply[];
+  createdAt: string;
+  updatedAt: string;
+}
+
+export type MeetingRequestStatus = "pending" | "scheduled" | "declined" | "cancelled";
+
+export interface MeetingRequest {
+  _id: string;
+  userId: string | { _id: string; name?: string; email?: string; role?: string };
+  topic: string;
+  preferredTimes: string;
+  durationMinutes: number;
+  status: MeetingRequestStatus;
+  adminResponse?: string;
+  scheduledAt?: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+async function asJson<T>(res: Response): Promise<T> {
+  const body = await res.json();
+  if (!res.ok || body?.success === false) {
+    throw new Error(body?.msg || `Request failed (${res.status})`);
+  }
+  return body.data as T;
+}
+
+export async function proListMyTickets(): Promise<SupportTicket[]> {
+  const res = await authFetch(`${API()}/api/professional/support/tickets`);
+  return (await asJson<{ items: SupportTicket[] }>(res)).items;
+}
+
+export async function proCreateTicket(payload: { subject: string; description: string }): Promise<SupportTicket> {
+  const res = await authFetch(`${API()}/api/professional/support/tickets`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(payload),
+  });
+  return asJson<SupportTicket>(res);
+}
+
+export async function proReplyTicket(id: string, body: string): Promise<SupportTicket> {
+  const res = await authFetch(`${API()}/api/professional/support/tickets/${id}/reply`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ body }),
+  });
+  return asJson<SupportTicket>(res);
+}
+
+export async function proListMyMeetingRequests(): Promise<MeetingRequest[]> {
+  const res = await authFetch(`${API()}/api/professional/support/meeting-requests`);
+  return (await asJson<{ items: MeetingRequest[] }>(res)).items;
+}
+
+export async function proCreateMeetingRequest(payload: {
+  topic: string;
+  preferredTimes: string;
+  durationMinutes: number;
+}): Promise<MeetingRequest> {
+  const res = await authFetch(`${API()}/api/professional/support/meeting-requests`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(payload),
+  });
+  return asJson<MeetingRequest>(res);
+}
+
+export async function adminListTickets(status?: SupportTicketStatus): Promise<SupportTicket[]> {
+  const qs = status ? `?status=${status}` : "";
+  const res = await authFetch(`${API()}/api/admin/support/tickets${qs}`);
+  return (await asJson<{ items: SupportTicket[] }>(res)).items;
+}
+
+export async function adminUpdateTicket(id: string, payload: { status?: SupportTicketStatus; reply?: string }): Promise<SupportTicket> {
+  const res = await authFetch(`${API()}/api/admin/support/tickets/${id}`, {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(payload),
+  });
+  return asJson<SupportTicket>(res);
+}
+
+export async function adminListMeetingRequests(status?: MeetingRequestStatus): Promise<MeetingRequest[]> {
+  const qs = status ? `?status=${status}` : "";
+  const res = await authFetch(`${API()}/api/admin/support/meeting-requests${qs}`);
+  return (await asJson<{ items: MeetingRequest[] }>(res)).items;
+}
+
+export async function adminUpdateMeetingRequest(id: string, payload: {
+  status?: MeetingRequestStatus;
+  adminResponse?: string;
+  scheduledAt?: string;
+}): Promise<MeetingRequest> {
+  const res = await authFetch(`${API()}/api/admin/support/meeting-requests/${id}`, {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(payload),
+  });
+  return asJson<MeetingRequest>(res);
+}


### PR DESCRIPTION
- Implemented AdminSocialSettingsPage for managing social media links.
- Created AdminSupportPage for handling support tickets and meeting requests.
- Developed ProfessionalSupportPage for professionals to create tickets and meeting requests.
- Added support for managing tickets and meeting requests in the backend.
- Introduced new API endpoints for site settings and support functionalities.
- Updated data models and interfaces for social links and support tickets.
- Removed unused footer links and social media links from content data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Professional Support: full ticket & meeting workflows for professionals and admins, plus admin support dashboard and quick access from Dashboard/Navbar.
  * Admin Social Settings and site settings management UI.
  * Project Favorite button and changed default Favorites tab.
  * CMS landing pages with dynamic SEO and a "View live" preview for content.

* **Improvements**
  * Footer, legal and social links now come from CMS/site settings.
  * Author attribution with writer-override support for posts.
  * FAQ items auto-open from URL hash.
  * Onboarding agreement labels link to policy pages when available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->