### PR TITLE
fix: add recommended cover image size display in CmsContentForm and C…

### DIFF
--- a/components/cms/CmsContentForm.tsx
+++ b/components/cms/CmsContentForm.tsx
@@ -120,6 +120,14 @@ export default function CmsContentForm({ mode, initial, lockedType, initialSlug,
   const isFaq = type === "faq";
   const slugPrefix = getPublicSlugPrefixForCms(type);
   const publicPreviewPath = form.slug ? getPublicPathForCms(type, form.slug) : null;
+  const coverRecommendation =
+    type === "landing"
+      ? "Recommended: 1600 × 700 px (16:7) — full-width page hero"
+      : type === "policy"
+      ? "Recommended: 1600 × 700 px (16:7) — page hero (optional)"
+      : type === "blog" || type === "news"
+      ? "Recommended: 1600 × 900 px (16:9) — used on cards and the article hero"
+      : "Recommended: 1600 × 900 px (16:9)";
 
   const update = (patch: Partial<CmsContent>) => setForm((f) => ({ ...f, ...patch }));
 
@@ -380,6 +388,7 @@ export default function CmsContentForm({ mode, initial, lockedType, initialSlug,
                 value={form.coverImage}
                 onChange={(url) => update({ coverImage: url })}
                 required={requiresCover}
+                recommendedSize={coverRecommendation}
               />
             </div>
           </GradientCard>

--- a/components/cms/CmsContentForm.tsx
+++ b/components/cms/CmsContentForm.tsx
@@ -36,6 +36,14 @@ interface Props {
   initialTitle?: string;
 }
 
+const COVER_RECOMMENDATIONS: Partial<Record<CmsContentType, string>> = {
+  blog: "Recommended: 1600 × 900 px (16:9) — used on cards and the article hero",
+  news: "Recommended: 1600 × 900 px (16:9) — used on cards and the article hero",
+  landing: "Recommended: 1600 × 700 px (16:7) — full-width page hero",
+  policy: "Recommended: 1600 × 700 px (16:7) — page hero (optional)",
+};
+const DEFAULT_COVER_RECOMMENDATION = "Recommended: 1600 × 900 px (16:9)";
+
 const EMPTY: Partial<CmsContent> = {
   type: "blog",
   title: "",
@@ -120,14 +128,7 @@ export default function CmsContentForm({ mode, initial, lockedType, initialSlug,
   const isFaq = type === "faq";
   const slugPrefix = getPublicSlugPrefixForCms(type);
   const publicPreviewPath = form.slug ? getPublicPathForCms(type, form.slug) : null;
-  const coverRecommendation =
-    type === "landing"
-      ? "Recommended: 1600 × 700 px (16:7) — full-width page hero"
-      : type === "policy"
-      ? "Recommended: 1600 × 700 px (16:7) — page hero (optional)"
-      : type === "blog" || type === "news"
-      ? "Recommended: 1600 × 900 px (16:9) — used on cards and the article hero"
-      : "Recommended: 1600 × 900 px (16:9)";
+  const coverRecommendation = COVER_RECOMMENDATIONS[type] ?? DEFAULT_COVER_RECOMMENDATION;
 
   const update = (patch: Partial<CmsContent>) => setForm((f) => ({ ...f, ...patch }));
 

--- a/components/cms/CoverImageUpload.tsx
+++ b/components/cms/CoverImageUpload.tsx
@@ -11,9 +11,10 @@ interface Props {
   value?: string;
   onChange: (url: string | undefined) => void;
   required?: boolean;
+  recommendedSize?: string;
 }
 
-export default function CoverImageUpload({ value, onChange, required }: Props) {
+export default function CoverImageUpload({ value, onChange, required, recommendedSize }: Props) {
   const [uploading, setUploading] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
 
@@ -85,6 +86,9 @@ export default function CoverImageUpload({ value, onChange, required }: Props) {
                 <>
                   <ImagePlus size={28} className="text-rose-500" />
                   <span className="text-sm font-medium">Click to upload cover image</span>
+                  {recommendedSize && (
+                    <span className="px-4 text-center text-xs font-medium text-rose-500">{recommendedSize}</span>
+                  )}
                   <span className="text-xs text-rose-400">JPEG, PNG, or WebP — up to 5MB</span>
                 </>
               )}
@@ -100,14 +104,19 @@ export default function CoverImageUpload({ value, onChange, required }: Props) {
         onChange={(e) => handle(e.target.files?.[0])}
       />
       {value && (
-        <button
-          type="button"
-          onClick={() => inputRef.current?.click()}
-          disabled={uploading}
-          className="inline-flex items-center gap-1 rounded-lg bg-gradient-to-r from-rose-100 to-pink-100 px-3 py-1.5 text-xs font-medium text-rose-700 hover:from-rose-200 hover:to-pink-200"
-        >
-          {uploading ? <Loader2 className="animate-spin" size={12} /> : <ImagePlus size={12} />} Replace image
-        </button>
+        <div className="flex flex-wrap items-center gap-2">
+          <button
+            type="button"
+            onClick={() => inputRef.current?.click()}
+            disabled={uploading}
+            className="inline-flex items-center gap-1 rounded-lg bg-gradient-to-r from-rose-100 to-pink-100 px-3 py-1.5 text-xs font-medium text-rose-700 hover:from-rose-200 hover:to-pink-200"
+          >
+            {uploading ? <Loader2 className="animate-spin" size={12} /> : <ImagePlus size={12} />} Replace image
+          </button>
+          {recommendedSize && (
+            <span className="text-[11px] text-rose-400">{recommendedSize}</span>
+          )}
+        </div>
       )}
     </div>
   );

--- a/components/cms/CoverImageUpload.tsx
+++ b/components/cms/CoverImageUpload.tsx
@@ -114,7 +114,7 @@ export default function CoverImageUpload({ value, onChange, required, recommende
             {uploading ? <Loader2 className="animate-spin" size={12} /> : <ImagePlus size={12} />} Replace image
           </button>
           {recommendedSize && (
-            <span className="text-[11px] text-rose-400">{recommendedSize}</span>
+            <span className="text-xs font-medium text-rose-500">{recommendedSize}</span>
           )}
         </div>
       )}


### PR DESCRIPTION
…overImageUpload components

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added recommended image size guidance for cover images: content-create/edit flows now show tailored dimension suggestions based on content type.
  * The cover upload UI displays the recommended size as a visible badge both on the initial upload prompt and next to the replace image control.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pankaj3399/fixera/pull/195?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->