### PR TITLE
feat: display selected options in payment breakdown and include in total

### DIFF
--- a/app/bookings/[id]/payment/page.tsx
+++ b/app/bookings/[id]/payment/page.tsx
@@ -1474,7 +1474,7 @@ export default function BookingPaymentPage() {
               </div>
             )}
             <div className="space-y-2">
-              {hasDiscountBreakdown && (
+              {(hasDiscountBreakdown || commissionedOptionsAmount > 0) && (
                 <div className="flex justify-between">
                   <span className="text-gray-600">Original Service Amount:</span>
                   <span className="text-gray-900">
@@ -1483,7 +1483,7 @@ export default function BookingPaymentPage() {
                 </div>
               )}
 
-              {hasDiscountBreakdown && commissionedOptionsAmount > 0 && (
+              {commissionedOptionsAmount > 0 && (
                 <div className="flex justify-between">
                   <span className="text-gray-600">Selected Options:</span>
                   <span className="text-gray-900">


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved payment breakdown display logic on the payment page to correctly show "Original Service Amount" and "Selected Options" sections when applicable, ensuring payment details are properly visible to users based on their booking configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->