### PR TITLE
feat(vat): phase 2 — booking wizard, quotation lines, and booking detail VAT

### DIFF
--- a/app/(pages)/bookings/[id]/page.tsx
+++ b/app/(pages)/bookings/[id]/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useRef, useState } from "react"
+import { useEffect, useMemo, useRef, useState } from "react"
 import { useRouter, useParams, useSearchParams } from "next/navigation"
 import { useAuth } from "@/contexts/AuthContext"
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card"
@@ -30,6 +30,10 @@ import type { QuoteVersion, BookingMilestone } from "@/types/quotation"
 import { BOOKING_STATUSES, type BookingStatus } from "@/lib/dashboardBookingHelpers"
 import { useCustomerPricing } from "@/hooks/useCustomerPricing"
 import { createOrGetConversation } from "@/lib/chatApi"
+import {
+  calculateMilestoneGrossAmounts,
+  calculateQuoteVersionVatTotals,
+} from "@/lib/vatPricing"
 
 const PRE_SERVICE_BOOKING_STATUSES: BookingStatus[] = BOOKING_STATUSES.filter((status) =>
   [
@@ -96,6 +100,16 @@ interface BookingDetail {
     netAmount?: number
     vatAmount?: number
     vatRate?: number
+    reverseCharge?: boolean
+    vatBreakdown?: Array<{
+      description: string
+      netAmount: number
+      vatRate: number
+      vatAmount: number
+      totalAmount: number
+      vatCountry?: string
+      vatLabel?: string
+    }>
     platformCommission?: number
     professionalPayout?: number
     stripeFeeAmount?: number
@@ -109,6 +123,15 @@ interface BookingDetail {
     paidAt?: string
     refundedAt?: string
     refundReason?: string
+    invoiceNumber?: string
+    invoiceUrl?: string
+    invoiceUblUrl?: string
+    invoiceGeneratedAt?: string
+    creditNoteNumber?: string
+    creditNoteUrl?: string
+    creditNoteUblUrl?: string
+    creditNoteGeneratedAt?: string
+    peppolDispatchStatus?: string
     discount?: {
       loyaltyTier?: string
       loyaltyAmount?: number
@@ -168,6 +191,17 @@ interface BookingDetail {
   customerRejectionReason?: string
   milestonePayments?: BookingMilestone[]
   selectedSubprojectIndex?: number
+  vatDecision?: {
+    action?: 'standard_rate' | 'reduced_rate' | 'rfq'
+    country?: string
+    standardRate?: number
+    appliedRate?: number
+    reducedRate?: number
+    reverseCharge?: boolean
+    explanation?: string
+    matchedRuleText?: string
+    answers?: { fieldName: string; value: string | number | boolean | string[] }[]
+  }
   scheduledStartDate?: string
   scheduledStartTime?: string
   scheduledEndTime?: string
@@ -541,6 +575,7 @@ export default function BookingDetailPage() {
   const [showRejectionModal, setShowRejectionModal] = useState(false)
   const [rejectionReason, setRejectionReason] = useState("")
   const [respondingToQuotation, setRespondingToQuotation] = useState(false)
+  const [proceedingAtStandardVat, setProceedingAtStandardVat] = useState(false)
   const [showQuoteRejectionModal, setShowQuoteRejectionModal] = useState(false)
   const [quoteRejectionReason, setQuoteRejectionReason] = useState("")
   const [versionHistoryOpen, setVersionHistoryOpen] = useState(false)
@@ -1387,6 +1422,37 @@ export default function BookingDetailPage() {
     }
   }
 
+  const handleProceedAtStandardVat = async () => {
+    if (!bookingId) return
+    setProceedingAtStandardVat(true)
+    try {
+      const token = getAuthToken()
+      const headers: Record<string, string> = { "Content-Type": "application/json" }
+      if (token) headers.Authorization = `Bearer ${token}`
+
+      const response = await fetch(
+        `${process.env.NEXT_PUBLIC_BACKEND_URL}/api/bookings/${bookingId}/vat-proceed-standard`,
+        { method: "POST", headers, credentials: "include" }
+      )
+      const { data } = await parseResponseBody<{ success?: boolean; msg?: string; booking?: BookingDetail }>(response)
+      if (response.ok && data?.success) {
+        toast.success(data.msg || "You can now proceed at the standard VAT rate.")
+        if (data.booking?.status === "quote_accepted" && data.booking?._id) {
+          router.push(`/bookings/${data.booking._id}/payment`)
+          return
+        }
+        await refreshBooking()
+      } else {
+        toast.error(data?.msg || "Unable to update VAT preference")
+      }
+    } catch (error) {
+      console.error("Proceed at standard VAT error:", error)
+      toast.error("Unable to update VAT preference")
+    } finally {
+      setProceedingAtStandardVat(false)
+    }
+  }
+
   const handleRespondToQuotation = async (action: 'accepted' | 'rejected') => {
     if (!bookingId) return
     if (action === 'rejected' && !quoteRejectionReason.trim()) {
@@ -1503,6 +1569,37 @@ export default function BookingDetailPage() {
   const currentVersion = hasQuotationVersions
     ? booking?.quoteVersions?.find(v => v.version === booking?.currentQuoteVersion)
     : null
+  const currentVersionQuoteTotals = useMemo(
+    () => calculateQuoteVersionVatTotals(
+      currentVersion,
+      customerPricingReady ? customerPrice : undefined
+    ),
+    [currentVersion, customerPricingReady, customerPrice]
+  )
+  const currentVersionMilestoneGrossAmounts = useMemo(
+    () => calculateMilestoneGrossAmounts(
+      currentVersion,
+      customerPricingReady ? customerPrice : undefined
+    ),
+    [currentVersion, customerPricingReady, customerPrice]
+  )
+  const currentVersionOriginalQuoteTotals = useMemo(
+    () => calculateQuoteVersionVatTotals(
+      currentVersion,
+      customerPricingReady ? originalPrice : undefined
+    ),
+    [currentVersion, customerPricingReady, originalPrice]
+  )
+  const bookingMilestoneGrossAmounts = useMemo(() => {
+    if (!booking?.milestonePayments?.length || !currentVersion) return []
+    return calculateMilestoneGrossAmounts(
+      {
+        ...currentVersion,
+        milestones: booking.milestonePayments,
+      },
+      user?.role === 'customer' && customerPricingReady ? customerPrice : undefined
+    )
+  }, [booking?.milestonePayments, currentVersion, user?.role, customerPricingReady, customerPrice])
   const rfqDeadlineDate = booking?.rfqDeadline ? new Date(booking.rfqDeadline) : null
   const rfqDeadlineRemaining = rfqDeadlineDate
     ? Math.max(0, Math.ceil((rfqDeadlineDate.getTime() - Date.now()) / (1000 * 60 * 60)))
@@ -2650,6 +2747,92 @@ export default function BookingDetailPage() {
                   </div>
                 )}
 
+                {user?.role === "customer" && booking.vatDecision?.action === "rfq" && !booking.vatDecision?.reverseCharge && (
+                  <div className="bg-gradient-to-r from-amber-50 to-orange-50 border border-amber-200 rounded-lg p-4 space-y-3">
+                    <div>
+                      <h3 className="text-sm font-semibold text-amber-900 mb-1">VAT review required</h3>
+                      <p className="text-xs text-amber-800">
+                        {booking.vatDecision.explanation || "Your answers suggest this booking may qualify for reduced VAT or needs a custom quotation review."}
+                      </p>
+                    </div>
+                    <div className="flex flex-wrap gap-2">
+                      {booking.professional?._id && (
+                        <StartChatButton
+                          professionalId={booking.professional._id}
+                          className="bg-white border-amber-200 hover:border-amber-300"
+                        />
+                      )}
+                      <Button
+                        size="sm"
+                        variant="outline"
+                        className="border-amber-300 text-amber-800 hover:bg-amber-100"
+                        onClick={handleProceedAtStandardVat}
+                        disabled={proceedingAtStandardVat}
+                      >
+                        {proceedingAtStandardVat ? (
+                          <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                        ) : (
+                          <CheckCircle className="h-4 w-4 mr-2" />
+                        )}
+                        Proceed at standard VAT rate
+                      </Button>
+                    </div>
+                  </div>
+                )}
+
+                {/* Professional: customer's answers triggered a VAT review */}
+                {user?.role === "professional" && booking.vatDecision?.action === "rfq" && !booking.vatDecision?.reverseCharge && (
+                  <div className="bg-gradient-to-r from-amber-50 to-orange-50 border border-amber-200 rounded-lg p-4">
+                    <h3 className="text-sm font-semibold text-amber-900 mb-1">VAT review requested</h3>
+                    <p className="text-xs text-amber-800">
+                      {booking.vatDecision.explanation ||
+                        "The customer's answers may qualify for a reduced VAT rate. Review their VAT answers below and reflect the correct rate in your quotation, or advise them via chat."}
+                    </p>
+                  </div>
+                )}
+
+                {/* Reduced VAT rate confirmed */}
+                {booking.vatDecision?.action === "reduced_rate" && (
+                  <div className="bg-gradient-to-r from-green-50 to-emerald-50 border border-green-200 rounded-lg p-4">
+                    <div className="flex items-start gap-3">
+                      <CheckCircle className="h-5 w-5 text-green-600 mt-0.5" />
+                      <div>
+                        <h3 className="text-sm font-semibold text-green-900 mb-1">
+                          Reduced VAT rate applied
+                          {typeof booking.vatDecision.appliedRate === "number" ? ` (${booking.vatDecision.appliedRate}%)` : ""}
+                        </h3>
+                        <p className="text-xs text-green-800">
+                          {booking.vatDecision.explanation || booking.vatDecision.matchedRuleText ||
+                            "This booking qualifies for a reduced VAT rate based on the answers provided."}
+                        </p>
+                      </div>
+                    </div>
+                  </div>
+                )}
+
+                {/* VAT answers provided by the customer (visible to professional/admin) */}
+                {(user?.role === "professional" || user?.role === "admin") &&
+                  Array.isArray(booking.vatDecision?.answers) &&
+                  booking.vatDecision.answers.length > 0 && (
+                  <div className="bg-white border border-gray-200 rounded-lg p-4">
+                    <h3 className="text-sm font-semibold text-gray-900 mb-2">Customer VAT answers</h3>
+                    <dl className="space-y-1">
+                      {booking.vatDecision.answers.map((answer) => (
+                        <div key={answer.fieldName} className="flex justify-between gap-4 text-xs">
+                          <dt className="text-gray-600 capitalize">{answer.fieldName.replace(/[_-]+/g, " ")}</dt>
+                          <dd className="font-medium text-gray-900 text-right">
+                            {Array.isArray(answer.value)
+                              ? answer.value.join(", ")
+                              : typeof answer.value === "boolean"
+                                ? answer.value ? "Yes" : "No"
+                                : String(answer.value ?? "—")}
+                          </dd>
+                        </div>
+                      ))}
+                    </dl>
+                  </div>
+                )}
+
                 {/* Professional: Quote Accepted - Waiting for Payment */}
                 {user?.role === "professional" && (booking.status === "quote_accepted" || booking.status === "payment_pending") && (
                   <div className="bg-gradient-to-r from-amber-50 to-yellow-50 border border-amber-200 rounded-lg p-4">
@@ -2913,23 +3096,74 @@ export default function BookingDetailPage() {
                             {currentVersion.milestones.map((ms, i) => (
                               <div key={i} className="flex justify-between items-center text-sm bg-gray-50 rounded px-2 py-1">
                                 <span className="text-gray-700">{ms.title}</span>
-                                <span className="font-medium">{customerPricingReady ? formatMoney(customerPrice(ms.amount), booking.quote?.currency || 'EUR') : '...'}</span>
+                                <span className="font-medium">
+                                  {customerPricingReady
+                                    ? formatMoney(currentVersionMilestoneGrossAmounts[i] ?? 0, booking.quote?.currency || 'EUR')
+                                    : '...'}
+                                </span>
                               </div>
                             ))}
+                          </div>
+                          {customerPricingReady && (
+                            <p className="mt-1 text-[11px] text-gray-500">
+                              Milestones are shown incl. VAT and allocated from the quotation gross total.
+                            </p>
+                          )}
+                        </div>
+                      )}
+                      {currentVersion.pricingLines && currentVersion.pricingLines.length > 0 && (
+                        <div>
+                          <p className="text-xs text-gray-500 font-medium mb-2">Pricing breakdown</p>
+                          <div className="rounded-md border overflow-hidden">
+                            <table className="w-full text-xs">
+                              <thead className="bg-gray-50 text-gray-600">
+                                <tr>
+                                  <th className="text-left px-3 py-2 font-medium">Description</th>
+                                  <th className="text-right px-3 py-2 font-medium">Net</th>
+                                  <th className="text-right px-3 py-2 font-medium">VAT</th>
+                                  <th className="text-right px-3 py-2 font-medium">Total</th>
+                                </tr>
+                              </thead>
+                              <tbody>
+                                {currentVersion.pricingLines.map((line, index) => {
+                                  const net = customerPricingReady ? customerPrice(line.price) : line.price
+                                  const vatAmount = net * ((line.vatRate || 0) / 100)
+                                  const total = net + vatAmount
+                                  return (
+                                    <tr key={index} className="border-t">
+                                      <td className="px-3 py-2 text-gray-800">
+                                        <div>{line.description}</div>
+                                        <div className="text-[10px] text-gray-500">
+                                          {line.vatLabel || `${line.vatRate}% VAT`}
+                                        </div>
+                                      </td>
+                                      <td className="px-3 py-2 text-right">{customerPricingReady ? formatMoney(net, currentVersion.currency || 'EUR') : '...'}</td>
+                                      <td className="px-3 py-2 text-right">{customerPricingReady ? formatMoney(vatAmount, currentVersion.currency || 'EUR') : '...'}</td>
+                                      <td className="px-3 py-2 text-right font-medium">{customerPricingReady ? formatMoney(total, currentVersion.currency || 'EUR') : '...'}</td>
+                                    </tr>
+                                  )
+                                })}
+                              </tbody>
+                            </table>
                           </div>
                         </div>
                       )}
                       <div className="flex justify-between items-center pt-2 border-t">
-                        <span className="text-sm font-semibold text-gray-900">Total</span>
-                        <span className="text-2xl font-bold text-green-600">{customerPricingReady ? formatMoney(customerPrice(currentVersion.totalAmount), booking.quote?.currency || 'EUR') : '...'}</span>
+                        <span className="text-sm font-semibold text-gray-900">Total (incl. VAT)</span>
+                        <span className="text-2xl font-bold text-green-600">{customerPricingReady ? formatMoney(currentVersionQuoteTotals.total, booking.quote?.currency || 'EUR') : '...'}</span>
                       </div>
+                      {customerPricingReady && currentVersionQuoteTotals.vatAmount > 0 && (
+                        <p className="text-xs text-gray-500 text-right">
+                          Net {formatMoney(currentVersionQuoteTotals.netAmount, booking.quote?.currency || 'EUR')} + VAT {formatMoney(currentVersionQuoteTotals.vatAmount, booking.quote?.currency || 'EUR')}
+                        </p>
+                      )}
                       {customerPricingReady && loyalty && loyalty.percentage > 0 && (
                         <div className="flex items-center justify-between rounded-md bg-amber-50 border border-amber-200 px-3 py-2">
                           <div className="text-xs text-amber-800">
                             <span className="font-semibold">{loyalty.level} Member</span> · {loyalty.percentage}% loyalty discount applied
                           </div>
                           <div className="text-xs font-semibold text-amber-900">
-                            You save {formatMoney(originalPrice(currentVersion.totalAmount) - customerPrice(currentVersion.totalAmount), booking.quote?.currency || 'EUR')}
+                            You save {formatMoney(currentVersionOriginalQuoteTotals.total - currentVersionQuoteTotals.total, booking.quote?.currency || 'EUR')}
                           </div>
                         </div>
                       )}
@@ -2956,7 +3190,7 @@ export default function BookingDetailPage() {
                                   <span className="font-medium">v{v.version}</span>
                                   <span className="text-xs text-gray-500">{new Date(v.createdAt).toLocaleDateString()}</span>
                                 </div>
-                                <p className="text-xs text-gray-600">{customerPricingReady ? formatMoney(customerPrice(v.totalAmount), booking.quote?.currency || 'EUR') : '...'}</p>
+                                <p className="text-xs text-gray-600">{customerPricingReady ? formatMoney(calculateQuoteVersionVatTotals(v, customerPrice).total, booking.quote?.currency || 'EUR') : '...'}</p>
                                 {v.changeNote && <p className="text-xs text-gray-500 italic mt-1">{v.changeNote}</p>}
                               </div>
                             ))}
@@ -3001,7 +3235,14 @@ export default function BookingDetailPage() {
                     </div>
                     <div className="bg-white rounded-lg p-3 space-y-2 text-sm">
                       <p><span className="text-gray-500">Scope:</span> {currentVersion.scope}</p>
-                      <p><span className="text-gray-500">Total:</span> <strong>{booking.quote?.currency || 'EUR'} {currentVersion.totalAmount.toFixed(2)}</strong></p>
+                      <p>
+                        <span className="text-gray-500">Net total:</span>{' '}
+                        <strong>{formatMoney(currentVersion.totalAmount, booking.quote?.currency || 'EUR')}</strong>
+                      </p>
+                      <p>
+                        <span className="text-gray-500">Total incl. VAT:</span>{' '}
+                        <strong>{formatMoney(calculateQuoteVersionVatTotals(currentVersion).total, booking.quote?.currency || 'EUR')}</strong>
+                      </p>
                       <p><span className="text-gray-500">Valid until:</span> {formatValidUntilLabel(currentVersion?.validUntil)}</p>
                       <p className="text-xs text-gray-500">Waiting for customer response...</p>
                     </div>
@@ -3057,13 +3298,24 @@ export default function BookingDetailPage() {
                     <h3 className="text-sm font-semibold text-sky-900 mb-3">Milestones</h3>
                     {(() => {
                       const isCustomerView = user?.role === 'customer'
-                      const displayAmount = (n: number) => isCustomerView && customerPricingReady ? customerPrice(n) : n
                       const total = booking.milestonePayments!.reduce((s, m) => s + m.amount, 0)
                       const paid = booking.milestonePayments!.filter(m => m.status === 'paid').reduce((s, m) => s + m.amount, 0)
                       const completed = booking.milestonePayments!.filter(m => (m.workStatus || 'pending') === 'completed').reduce((s, m) => s + m.amount, 0)
+                      const displayAmounts = booking.milestonePayments!.map((milestone, index) =>
+                        isCustomerView && customerPricingReady
+                          ? bookingMilestoneGrossAmounts[index] ?? 0
+                          : milestone.amount
+                      )
+                      const displayPaid = booking.milestonePayments!.reduce((sum, milestone, index) =>
+                        milestone.status === 'paid' ? sum + (displayAmounts[index] || 0) : sum
+                      , 0)
+                      const displayCompleted = booking.milestonePayments!.reduce((sum, milestone, index) =>
+                        (milestone.workStatus || 'pending') === 'completed' ? sum + (displayAmounts[index] || 0) : sum
+                      , 0)
                       const paymentPct = total > 0 ? Math.round((paid / total) * 100) : 0
                       const workPct = total > 0 ? Math.round((completed / total) * 100) : 0
                       const showAmounts = !isCustomerView || customerPricingReady
+                      const amountLabel = isCustomerView ? 'incl. VAT' : 'net'
                       return (
                         <div className="mb-4 space-y-3">
                           <div>
@@ -3085,8 +3337,8 @@ export default function BookingDetailPage() {
                             </div>
                           </div>
                           <div className="flex justify-between text-xs text-gray-600">
-                            <span>{booking.quote?.currency || 'EUR'} {showAmounts ? displayAmount(completed).toFixed(2) : '...'} completed</span>
-                            <span>{booking.quote?.currency || 'EUR'} {showAmounts ? displayAmount(paid).toFixed(2) : '...'} paid</span>
+                            <span>{booking.quote?.currency || 'EUR'} {showAmounts ? displayCompleted.toFixed(2) : '...'} completed ({amountLabel})</span>
+                            <span>{booking.quote?.currency || 'EUR'} {showAmounts ? displayPaid.toFixed(2) : '...'} paid ({amountLabel})</span>
                           </div>
                         </div>
                       )
@@ -3142,8 +3394,9 @@ export default function BookingDetailPage() {
                                   <p className="text-xs text-gray-500">
                                     {booking.quote?.currency || 'EUR'}{' '}
                                     {user?.role === 'customer'
-                                      ? (customerPricingReady ? customerPrice(ms.amount).toFixed(2) : '...')
+                                      ? (customerPricingReady ? (bookingMilestoneGrossAmounts[i] ?? 0).toFixed(2) : '...')
                                       : ms.amount.toFixed(2)}
+                                    {user?.role === 'customer' ? ' incl. VAT' : ' net'}
                                   </p>
                                   {dueLabel && !isPaid && (
                                     <p className="text-[11px] text-sky-700">{dueLabel}</p>
@@ -3220,7 +3473,7 @@ export default function BookingDetailPage() {
                     <div className="bg-white rounded-lg p-4 mb-4 space-y-2">
                       {/* Original quote amount */}
                       <div className="flex justify-between items-center">
-                        <span className="text-sm text-gray-600">Quote Amount:</span>
+                        <span className="text-sm text-gray-600">Quote Amount (excl. VAT):</span>
                         <span className={`text-2xl font-bold ${discountPreview && discountPreview.totalDiscount > 0 ? "text-gray-400 line-through text-lg" : "text-green-600"}`}>
                           {booking.quote.currency || "€"}{booking.quote.amount != null ? booking.quote.amount.toLocaleString() : "—"}
                         </span>
@@ -4508,6 +4761,16 @@ export default function BookingDetailPage() {
                             <span>{booking.payment.currency || 'EUR'} {booking.payment.vatAmount.toFixed(2)}</span>
                           </div>
                         )}
+                        {booking.payment.reverseCharge && (
+                          <div className="rounded-md border border-blue-100 bg-blue-50 p-2 text-[11px] text-blue-800">
+                            0% VAT applied: Intra-Community supply, VAT exempt under Article 39bis of the VAT Directive.
+                          </div>
+                        )}
+                        {booking.vatDecision?.explanation && (
+                          <div className="rounded-md border border-emerald-100 bg-emerald-50 p-2 text-[11px] text-emerald-800">
+                            {booking.vatDecision.explanation}
+                          </div>
+                        )}
                         {booking.payment.totalWithVat != null && (
                           <div className="flex justify-between font-medium">
                             <span>Total (incl. VAT)</span>
@@ -4553,6 +4816,56 @@ export default function BookingDetailPage() {
                         {booking.payment.stripePaymentIntentId && (
                           <div className="border-t border-gray-200 pt-1.5 mt-1.5">
                             <p className="text-[10px] text-gray-400 break-all">PI: {booking.payment.stripePaymentIntentId}</p>
+                          </div>
+                        )}
+                      </CardContent>
+                    </Card>
+                  )}
+
+                  {booking.payment?.invoiceUrl && (
+                    <Card className="bg-slate-50/60 border border-slate-100">
+                      <CardHeader className="pb-2">
+                        <CardTitle className="flex items-center gap-2 text-xs">
+                          <FileText className="h-4 w-4 text-slate-600" />
+                          Invoice
+                        </CardTitle>
+                      </CardHeader>
+                      <CardContent className="space-y-2 text-xs text-gray-700">
+                        <div className="flex justify-between">
+                          <span className="text-gray-500">Invoice #</span>
+                          <span>{booking.payment.invoiceNumber || 'Generated'}</span>
+                        </div>
+                        <div className="flex flex-wrap gap-2">
+                          <Button asChild size="sm" variant="outline" className="h-8 text-xs">
+                            <a href={booking.payment.invoiceUrl} target="_blank" rel="noreferrer">Download PDF</a>
+                          </Button>
+                          {booking.payment.invoiceUblUrl && (
+                            <Button asChild size="sm" variant="outline" className="h-8 text-xs">
+                              <a href={booking.payment.invoiceUblUrl} target="_blank" rel="noreferrer">Download UBL</a>
+                            </Button>
+                          )}
+                        </div>
+                        {booking.payment.peppolDispatchStatus && booking.payment.peppolDispatchStatus !== 'skipped' && (
+                          <p className="text-[11px] text-gray-500">
+                            Peppol status: {booking.payment.peppolDispatchStatus}
+                          </p>
+                        )}
+                        {booking.payment.creditNoteUrl && (
+                          <div className="border-t border-gray-200 pt-2 space-y-2">
+                            <div className="flex justify-between">
+                              <span className="text-gray-500">Credit note #</span>
+                              <span>{booking.payment.creditNoteNumber}</span>
+                            </div>
+                            <div className="flex flex-wrap gap-2">
+                              <Button asChild size="sm" variant="outline" className="h-8 text-xs">
+                                <a href={booking.payment.creditNoteUrl} target="_blank" rel="noreferrer">Credit note PDF</a>
+                              </Button>
+                              {booking.payment.creditNoteUblUrl && (
+                                <Button asChild size="sm" variant="outline" className="h-8 text-xs">
+                                  <a href={booking.payment.creditNoteUblUrl} target="_blank" rel="noreferrer">Credit note UBL</a>
+                                </Button>
+                              )}
+                            </div>
                           </div>
                         )}
                       </CardContent>

--- a/components/ServiceConfigurationManagement.tsx
+++ b/components/ServiceConfigurationManagement.tsx
@@ -479,11 +479,18 @@ export default function ServiceConfigurationManagement() {
 
     const vat = ensureVatManagement(formData.vatManagement)
     if (vat.enabled) {
+      const seenFieldNames = new Set<string>()
       for (const question of vat.reducedVatQuestions) {
         if (!question.question.trim() || !question.fieldName.trim()) {
           toast.error('Each VAT question needs a question and field name')
           return
         }
+        const fieldName = question.fieldName.trim()
+        if (seenFieldNames.has(fieldName)) {
+          toast.error(`Duplicate VAT question field name "${fieldName}"`)
+          return
+        }
+        seenFieldNames.add(fieldName)
         if (question.answerType === 'checkboxes' && (!question.options || question.options.length === 0)) {
           toast.error(`VAT question "${question.question}" needs checkbox options`)
           return
@@ -497,6 +504,12 @@ export default function ServiceConfigurationManagement() {
         if (rule.standardRate <= 0 || rule.standardRate > 100 || rule.reducedRate < 0 || rule.reducedRate > rule.standardRate) {
           toast.error('Each VAT logic rule needs a positive standard rate and a reduced rate between 0 and the standard rate')
           return
+        }
+        for (const condition of rule.conditions) {
+          if (!condition.fieldName?.trim()) {
+            toast.error('Each VAT logic condition needs a field name')
+            return
+          }
         }
       }
     }

--- a/components/ServiceConfigurationManagement.tsx
+++ b/components/ServiceConfigurationManagement.tsx
@@ -65,6 +65,7 @@ interface PricingOption {
 }
 
 interface VatQuestion {
+  clientKey?: string
   question: string
   fieldName: string
   answerType: 'number' | 'yes_no' | 'checkboxes'
@@ -74,6 +75,7 @@ interface VatQuestion {
 }
 
 interface VatLogicCondition {
+  clientKey?: string
   fieldName: string
   operator: 'equals' | 'not_equals' | 'greater_than' | 'greater_than_or_equal' | 'less_than' | 'less_than_or_equal' | 'includes'
   value: string | number | boolean
@@ -81,6 +83,7 @@ interface VatLogicCondition {
 }
 
 interface VatLogicRule {
+  clientKey?: string
   country: string
   standardRate: number
   reducedRate: number
@@ -491,8 +494,8 @@ export default function ServiceConfigurationManagement() {
           toast.error('Each VAT logic rule needs a country')
           return
         }
-        if (!Number.isFinite(Number(rule.standardRate)) || !Number.isFinite(Number(rule.reducedRate))) {
-          toast.error('Each VAT logic rule needs standard and reduced VAT rates')
+        if (rule.standardRate <= 0 || rule.standardRate > 100 || rule.reducedRate < 0 || rule.reducedRate > rule.standardRate) {
+          toast.error('Each VAT logic rule needs a positive standard rate and a reduced rate between 0 and the standard rate')
           return
         }
       }
@@ -637,11 +640,23 @@ export default function ServiceConfigurationManagement() {
     }))
   }
 
+  const makeClientKey = (prefix: string) => `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`
+
   const ensureVatManagement = (vat?: VatManagement): VatManagement => ({
     enabled: vat?.enabled ?? false,
     rateRuleGroup: vat?.rateRuleGroup || '',
-    reducedVatQuestions: vat?.reducedVatQuestions || [],
-    logicRules: vat?.logicRules || [],
+    reducedVatQuestions: (vat?.reducedVatQuestions || []).map((question) => ({
+      ...question,
+      clientKey: question.clientKey || makeClientKey('vat-question'),
+    })),
+    logicRules: (vat?.logicRules || []).map((rule) => ({
+      ...rule,
+      clientKey: rule.clientKey || makeClientKey('vat-rule'),
+      conditions: (rule.conditions || []).map((condition) => ({
+        ...condition,
+        clientKey: condition.clientKey || makeClientKey('vat-condition'),
+      })),
+    })),
   })
 
   const updateVatManagement = (patch: Partial<VatManagement>) => {
@@ -656,7 +671,7 @@ export default function ServiceConfigurationManagement() {
     updateVatManagement({
       reducedVatQuestions: [
         ...vat.reducedVatQuestions,
-        { question: '', fieldName: '', answerType: 'yes_no', unit: '', options: [], isRequired: true }
+        { question: '', fieldName: '', answerType: 'yes_no', unit: '', options: [], isRequired: true, clientKey: makeClientKey('vat-question') }
       ]
     })
   }
@@ -691,6 +706,7 @@ export default function ServiceConfigurationManagement() {
           customText: '',
           priority: vat.logicRules.length,
           isActive: true,
+          clientKey: makeClientKey('vat-rule'),
         }
       ]
     })
@@ -718,7 +734,7 @@ export default function ServiceConfigurationManagement() {
               ...rule,
               conditions: [
                 ...rule.conditions,
-                { fieldName, operator: 'equals', value: true, connector: rule.conditions.length === 0 ? 'AND' : 'AND' }
+                { fieldName, operator: 'equals', value: true, connector: rule.conditions.length === 0 ? 'AND' : 'AND', clientKey: makeClientKey('vat-condition') }
               ]
             }
           : rule
@@ -1354,7 +1370,7 @@ export default function ServiceConfigurationManagement() {
                       </Button>
                     </div>
                     {(formData.vatManagement.reducedVatQuestions || []).map((question, index) => (
-                      <div key={index} className="p-3 border rounded-lg bg-gray-50 space-y-2">
+                      <div key={question.clientKey || question.fieldName || `vat-question-${index}`} className="p-3 border rounded-lg bg-gray-50 space-y-2">
                         <div className="grid grid-cols-1 md:grid-cols-[1fr_180px_150px_100px_40px] gap-2">
                           <Input
                             value={question.question}
@@ -1418,7 +1434,7 @@ export default function ServiceConfigurationManagement() {
                       </Button>
                     </div>
                     {(formData.vatManagement.logicRules || []).map((rule, ruleIndex) => (
-                      <div key={ruleIndex} className="p-3 border rounded-lg bg-gray-50 space-y-3">
+                      <div key={rule.clientKey || `${rule.country}-${rule.priority}-${ruleIndex}`} className="p-3 border rounded-lg bg-gray-50 space-y-3">
                         <div className="grid grid-cols-1 md:grid-cols-[100px_120px_120px_150px_90px_40px] gap-2">
                           <Input value={rule.country} onChange={(e) => updateVatLogicRule(ruleIndex, { country: e.target.value.toUpperCase() })} placeholder="BE" className="bg-white" />
                           <Input type="number" step={0.1} value={rule.standardRate} onChange={(e) => updateVatLogicRule(ruleIndex, { standardRate: parseFloat(e.target.value) || 0 })} placeholder="Standard %" className="bg-white" />
@@ -1456,7 +1472,7 @@ export default function ServiceConfigurationManagement() {
                             </Button>
                           </div>
                           {rule.conditions.map((condition, conditionIndex) => (
-                            <div key={conditionIndex} className="grid grid-cols-1 md:grid-cols-[80px_1fr_180px_1fr_40px] gap-2">
+                            <div key={condition.clientKey || `${condition.fieldName}-${condition.operator}-${conditionIndex}`} className="grid grid-cols-1 md:grid-cols-[80px_1fr_180px_1fr_40px] gap-2">
                               <select
                                 className="border rounded-md px-2 py-2 bg-white text-sm"
                                 value={condition.connector || 'AND'}

--- a/components/ServiceConfigurationManagement.tsx
+++ b/components/ServiceConfigurationManagement.tsx
@@ -64,6 +64,40 @@ interface PricingOption {
   unit?: string
 }
 
+interface VatQuestion {
+  question: string
+  fieldName: string
+  answerType: 'number' | 'yes_no' | 'checkboxes'
+  unit?: string
+  options?: string[]
+  isRequired: boolean
+}
+
+interface VatLogicCondition {
+  fieldName: string
+  operator: 'equals' | 'not_equals' | 'greater_than' | 'greater_than_or_equal' | 'less_than' | 'less_than_or_equal' | 'includes'
+  value: string | number | boolean
+  connector?: 'AND' | 'OR'
+}
+
+interface VatLogicRule {
+  country: string
+  standardRate: number
+  reducedRate: number
+  conditions: VatLogicCondition[]
+  action: 'reduced_rate' | 'rfq'
+  customText?: string
+  priority: number
+  isActive: boolean
+}
+
+interface VatManagement {
+  enabled: boolean
+  rateRuleGroup?: string
+  reducedVatQuestions: VatQuestion[]
+  logicRules: VatLogicRule[]
+}
+
 interface ServiceConfiguration {
   _id?: string
   category: string
@@ -79,6 +113,7 @@ interface ServiceConfiguration {
   professionalInputFields: DynamicField[]
   extraOptions: ExtraOption[]
   conditionsAndWarnings: ConditionWarning[]
+  vatManagement?: VatManagement
   isActive: boolean
   country?: string
   activeCountries?: string[]
@@ -106,6 +141,12 @@ const EMPTY_FORM: ServiceConfiguration = {
   professionalInputFields: [],
   extraOptions: [],
   conditionsAndWarnings: [],
+  vatManagement: {
+    enabled: false,
+    rateRuleGroup: '',
+    reducedVatQuestions: [],
+    logicRules: [],
+  },
   isActive: true,
   activeCountries: ['BE']
 }
@@ -433,6 +474,30 @@ export default function ServiceConfigurationManagement() {
       }
     }
 
+    const vat = ensureVatManagement(formData.vatManagement)
+    if (vat.enabled) {
+      for (const question of vat.reducedVatQuestions) {
+        if (!question.question.trim() || !question.fieldName.trim()) {
+          toast.error('Each VAT question needs a question and field name')
+          return
+        }
+        if (question.answerType === 'checkboxes' && (!question.options || question.options.length === 0)) {
+          toast.error(`VAT question "${question.question}" needs checkbox options`)
+          return
+        }
+      }
+      for (const rule of vat.logicRules) {
+        if (!rule.country.trim()) {
+          toast.error('Each VAT logic rule needs a country')
+          return
+        }
+        if (!Number.isFinite(Number(rule.standardRate)) || !Number.isFinite(Number(rule.reducedRate))) {
+          toast.error('Each VAT logic rule needs standard and reduced VAT rates')
+          return
+        }
+      }
+    }
+
     if (editingId) {
       updateService(editingId)
     } else {
@@ -570,6 +635,122 @@ export default function ServiceConfigurationManagement() {
         i === index ? ({ ...cw, [field]: value } as ConditionWarning) : cw
       )
     }))
+  }
+
+  const ensureVatManagement = (vat?: VatManagement): VatManagement => ({
+    enabled: vat?.enabled ?? false,
+    rateRuleGroup: vat?.rateRuleGroup || '',
+    reducedVatQuestions: vat?.reducedVatQuestions || [],
+    logicRules: vat?.logicRules || [],
+  })
+
+  const updateVatManagement = (patch: Partial<VatManagement>) => {
+    setFormData(prev => ({
+      ...prev,
+      vatManagement: { ...ensureVatManagement(prev.vatManagement), ...patch }
+    }))
+  }
+
+  const addVatQuestion = () => {
+    const vat = ensureVatManagement(formData.vatManagement)
+    updateVatManagement({
+      reducedVatQuestions: [
+        ...vat.reducedVatQuestions,
+        { question: '', fieldName: '', answerType: 'yes_no', unit: '', options: [], isRequired: true }
+      ]
+    })
+  }
+
+  const updateVatQuestion = (index: number, patch: Partial<VatQuestion>) => {
+    const vat = ensureVatManagement(formData.vatManagement)
+    updateVatManagement({
+      reducedVatQuestions: vat.reducedVatQuestions.map((question, i) =>
+        i === index ? { ...question, ...patch } : question
+      )
+    })
+  }
+
+  const removeVatQuestion = (index: number) => {
+    const vat = ensureVatManagement(formData.vatManagement)
+    updateVatManagement({
+      reducedVatQuestions: vat.reducedVatQuestions.filter((_, i) => i !== index)
+    })
+  }
+
+  const addVatLogicRule = () => {
+    const vat = ensureVatManagement(formData.vatManagement)
+    updateVatManagement({
+      logicRules: [
+        ...vat.logicRules,
+        {
+          country: 'BE',
+          standardRate: 21,
+          reducedRate: 6,
+          conditions: [],
+          action: 'reduced_rate',
+          customText: '',
+          priority: vat.logicRules.length,
+          isActive: true,
+        }
+      ]
+    })
+  }
+
+  const updateVatLogicRule = (index: number, patch: Partial<VatLogicRule>) => {
+    const vat = ensureVatManagement(formData.vatManagement)
+    updateVatManagement({
+      logicRules: vat.logicRules.map((rule, i) => i === index ? { ...rule, ...patch } : rule)
+    })
+  }
+
+  const removeVatLogicRule = (index: number) => {
+    const vat = ensureVatManagement(formData.vatManagement)
+    updateVatManagement({ logicRules: vat.logicRules.filter((_, i) => i !== index) })
+  }
+
+  const addVatCondition = (ruleIndex: number) => {
+    const vat = ensureVatManagement(formData.vatManagement)
+    const fieldName = vat.reducedVatQuestions[0]?.fieldName || ''
+    updateVatManagement({
+      logicRules: vat.logicRules.map((rule, i) =>
+        i === ruleIndex
+          ? {
+              ...rule,
+              conditions: [
+                ...rule.conditions,
+                { fieldName, operator: 'equals', value: true, connector: rule.conditions.length === 0 ? 'AND' : 'AND' }
+              ]
+            }
+          : rule
+      )
+    })
+  }
+
+  const updateVatCondition = (ruleIndex: number, conditionIndex: number, patch: Partial<VatLogicCondition>) => {
+    const vat = ensureVatManagement(formData.vatManagement)
+    updateVatManagement({
+      logicRules: vat.logicRules.map((rule, i) =>
+        i === ruleIndex
+          ? {
+              ...rule,
+              conditions: rule.conditions.map((condition, ci) =>
+                ci === conditionIndex ? { ...condition, ...patch } : condition
+              )
+            }
+          : rule
+      )
+    })
+  }
+
+  const removeVatCondition = (ruleIndex: number, conditionIndex: number) => {
+    const vat = ensureVatManagement(formData.vatManagement)
+    updateVatManagement({
+      logicRules: vat.logicRules.map((rule, i) =>
+        i === ruleIndex
+          ? { ...rule, conditions: rule.conditions.filter((_, ci) => ci !== conditionIndex) }
+          : rule
+      )
+    })
   }
 
   useEffect(() => {
@@ -1141,6 +1322,188 @@ export default function ServiceConfigurationManagement() {
                   <p className="text-sm text-muted-foreground">No conditions or warnings added yet</p>
                 )}
               </div>
+            </div>
+
+            {/* VAT Management */}
+            <div className="space-y-4 p-4 rounded-lg border-2 border-transparent bg-white relative before:absolute before:inset-0 before:rounded-lg before:p-[1px] before:bg-gradient-to-br before:from-emerald-200 before:to-cyan-200 before:-z-10">
+              <div className="flex items-center justify-between">
+                <h3 className="font-semibold text-lg">VAT management</h3>
+                <Switch
+                  id="vat-enabled"
+                  checked={!!formData.vatManagement?.enabled}
+                  onCheckedChange={(checked) => updateVatManagement({ enabled: Boolean(checked) })}
+                />
+              </div>
+
+              {formData.vatManagement?.enabled && (
+                <div className="space-y-5">
+                  <div className="space-y-2">
+                    <Label>Rate rule group</Label>
+                    <Input
+                      value={formData.vatManagement.rateRuleGroup || ''}
+                      onChange={(e) => updateVatManagement({ rateRuleGroup: e.target.value })}
+                      placeholder="e.g., building_work, solar, renovation_category"
+                    />
+                  </div>
+
+                  <div className="space-y-3">
+                    <div className="flex items-center justify-between">
+                      <Label>Reduced VAT questions</Label>
+                      <Button type="button" size="sm" variant="outline" onClick={addVatQuestion}>
+                        <Plus className="h-4 w-4 mr-1" /> Add Question
+                      </Button>
+                    </div>
+                    {(formData.vatManagement.reducedVatQuestions || []).map((question, index) => (
+                      <div key={index} className="p-3 border rounded-lg bg-gray-50 space-y-2">
+                        <div className="grid grid-cols-1 md:grid-cols-[1fr_180px_150px_100px_40px] gap-2">
+                          <Input
+                            value={question.question}
+                            onChange={(e) => updateVatQuestion(index, { question: e.target.value })}
+                            placeholder="Question shown in booking wizard"
+                            className="bg-white"
+                          />
+                          <Input
+                            value={question.fieldName}
+                            onChange={(e) => updateVatQuestion(index, { fieldName: e.target.value })}
+                            placeholder="field_name"
+                            className="bg-white"
+                          />
+                          <select
+                            className="border rounded-md px-3 py-2 bg-white text-sm"
+                            value={question.answerType}
+                            onChange={(e) => updateVatQuestion(index, { answerType: e.target.value as VatQuestion['answerType'] })}
+                          >
+                            <option value="yes_no">Yes/No</option>
+                            <option value="number">Number</option>
+                            <option value="checkboxes">Checkboxes</option>
+                          </select>
+                          <Input
+                            value={question.unit || ''}
+                            onChange={(e) => updateVatQuestion(index, { unit: e.target.value })}
+                            placeholder="Unit"
+                            disabled={question.answerType !== 'number'}
+                            className="bg-white"
+                          />
+                          <Button type="button" variant="ghost" size="icon" onClick={() => removeVatQuestion(index)}>
+                            <X className="h-4 w-4 text-red-600" />
+                          </Button>
+                        </div>
+                        {question.answerType === 'checkboxes' && (
+                          <Input
+                            value={(question.options || []).join(', ')}
+                            onChange={(e) => updateVatQuestion(index, { options: e.target.value.split(',').map(v => v.trim()).filter(Boolean) })}
+                            placeholder="Checkbox options, comma separated"
+                            className="bg-white"
+                          />
+                        )}
+                        <div className="flex items-center space-x-2">
+                          <Switch
+                            checked={question.isRequired !== false}
+                            onCheckedChange={(checked) => updateVatQuestion(index, { isRequired: checked })}
+                          />
+                          <Label className="text-xs">Required question</Label>
+                        </div>
+                      </div>
+                    ))}
+                    {(!formData.vatManagement.reducedVatQuestions || formData.vatManagement.reducedVatQuestions.length === 0) && (
+                      <p className="text-sm text-muted-foreground">No reduced VAT questions added yet</p>
+                    )}
+                  </div>
+
+                  <div className="space-y-3">
+                    <div className="flex items-center justify-between">
+                      <Label>Logic determination</Label>
+                      <Button type="button" size="sm" variant="outline" onClick={addVatLogicRule}>
+                        <Plus className="h-4 w-4 mr-1" /> Add Rule
+                      </Button>
+                    </div>
+                    {(formData.vatManagement.logicRules || []).map((rule, ruleIndex) => (
+                      <div key={ruleIndex} className="p-3 border rounded-lg bg-gray-50 space-y-3">
+                        <div className="grid grid-cols-1 md:grid-cols-[100px_120px_120px_150px_90px_40px] gap-2">
+                          <Input value={rule.country} onChange={(e) => updateVatLogicRule(ruleIndex, { country: e.target.value.toUpperCase() })} placeholder="BE" className="bg-white" />
+                          <Input type="number" step={0.1} value={rule.standardRate} onChange={(e) => updateVatLogicRule(ruleIndex, { standardRate: parseFloat(e.target.value) || 0 })} placeholder="Standard %" className="bg-white" />
+                          <Input type="number" step={0.1} value={rule.reducedRate} onChange={(e) => updateVatLogicRule(ruleIndex, { reducedRate: parseFloat(e.target.value) || 0 })} placeholder="Reduced %" className="bg-white" />
+                          <select className="border rounded-md px-3 py-2 bg-white text-sm" value={rule.action} onChange={(e) => updateVatLogicRule(ruleIndex, { action: e.target.value as VatLogicRule['action'] })}>
+                            <option value="reduced_rate">Reduced rate</option>
+                            <option value="rfq">RFQ</option>
+                          </select>
+                          <Input type="number" value={rule.priority} onChange={(e) => updateVatLogicRule(ruleIndex, { priority: parseInt(e.target.value, 10) || 0 })} placeholder="Priority" className="bg-white" />
+                          <Button type="button" variant="ghost" size="icon" onClick={() => removeVatLogicRule(ruleIndex)}>
+                            <X className="h-4 w-4 text-red-600" />
+                          </Button>
+                        </div>
+
+                        <Input
+                          value={rule.customText || ''}
+                          onChange={(e) => updateVatLogicRule(ruleIndex, { customText: e.target.value })}
+                          placeholder="Custom text shown when this logic is met"
+                          className="bg-white"
+                        />
+
+                        <div className="flex items-center space-x-2">
+                          <Switch
+                            checked={rule.isActive !== false}
+                            onCheckedChange={(checked) => updateVatLogicRule(ruleIndex, { isActive: checked })}
+                          />
+                          <Label className="text-xs">Rule active</Label>
+                        </div>
+
+                        <div className="space-y-2">
+                          <div className="flex items-center justify-between">
+                            <span className="text-sm font-medium">IF conditions</span>
+                            <Button type="button" size="sm" variant="outline" onClick={() => addVatCondition(ruleIndex)}>
+                              <Plus className="h-4 w-4 mr-1" /> Add Condition
+                            </Button>
+                          </div>
+                          {rule.conditions.map((condition, conditionIndex) => (
+                            <div key={conditionIndex} className="grid grid-cols-1 md:grid-cols-[80px_1fr_180px_1fr_40px] gap-2">
+                              <select
+                                className="border rounded-md px-2 py-2 bg-white text-sm"
+                                value={condition.connector || 'AND'}
+                                onChange={(e) => updateVatCondition(ruleIndex, conditionIndex, { connector: e.target.value as 'AND' | 'OR' })}
+                                disabled={conditionIndex === 0}
+                              >
+                                <option value="AND">AND</option>
+                                <option value="OR">OR</option>
+                              </select>
+                              <select
+                                className="border rounded-md px-3 py-2 bg-white text-sm"
+                                value={condition.fieldName}
+                                onChange={(e) => updateVatCondition(ruleIndex, conditionIndex, { fieldName: e.target.value })}
+                              >
+                                <option value="">Select field</option>
+                                {formData.vatManagement?.reducedVatQuestions.map(q => (
+                                  <option key={q.fieldName} value={q.fieldName}>{q.fieldName}</option>
+                                ))}
+                              </select>
+                              <select
+                                className="border rounded-md px-3 py-2 bg-white text-sm"
+                                value={condition.operator}
+                                onChange={(e) => updateVatCondition(ruleIndex, conditionIndex, { operator: e.target.value as VatLogicCondition['operator'] })}
+                              >
+                                <option value="equals">equals</option>
+                                <option value="not_equals">not equals</option>
+                                <option value="greater_than">greater than</option>
+                                <option value="greater_than_or_equal">greater/equal</option>
+                                <option value="less_than">less than</option>
+                                <option value="less_than_or_equal">less/equal</option>
+                                <option value="includes">includes</option>
+                              </select>
+                              <Input value={String(condition.value)} onChange={(e) => updateVatCondition(ruleIndex, conditionIndex, { value: e.target.value })} placeholder="Value" className="bg-white" />
+                              <Button type="button" variant="ghost" size="icon" onClick={() => removeVatCondition(ruleIndex, conditionIndex)}>
+                                <X className="h-4 w-4 text-red-600" />
+                              </Button>
+                            </div>
+                          ))}
+                        </div>
+                      </div>
+                    ))}
+                    {(!formData.vatManagement.logicRules || formData.vatManagement.logicRules.length === 0) && (
+                      <p className="text-sm text-muted-foreground">No VAT logic rules added yet</p>
+                    )}
+                  </div>
+                </div>
+              )}
             </div>
 
             {/* Included Items */}

--- a/components/project/ProjectBookingForm.tsx
+++ b/components/project/ProjectBookingForm.tsx
@@ -334,7 +334,11 @@ export default function ProjectBookingForm({
   // Best-effort VAT preview for the review step. Checkout always uses the
   // backend-computed decision, so failures here are silently ignored.
   useEffect(() => {
-    if (currentStep !== 4) return;
+    if (currentStep !== 4) {
+      setVatPreview(null);
+      return;
+    }
+    setVatPreview(null);
     let cancelled = false;
     (async () => {
       try {
@@ -3896,7 +3900,7 @@ export default function ProjectBookingForm({
                 ))}
                 </>)}
 
-                {project.vatManagement?.enabled && project.vatManagement.reducedVatQuestions.length > 0 && (
+                {project.vatManagement?.enabled && (project.vatManagement.reducedVatQuestions?.length ?? 0) > 0 && (
                   <div className='space-y-4 pt-4 border-t'>
                     <div>
                       <h2 className='text-xl font-semibold mb-2'>Reduced VAT questions</h2>
@@ -3905,7 +3909,7 @@ export default function ProjectBookingForm({
                       </p>
                     </div>
 
-                    {project.vatManagement.reducedVatQuestions.map((question) => {
+                    {(project.vatManagement.reducedVatQuestions || []).map((question) => {
                       const value = vatAnswers[question.fieldName]?.value;
                       return (
                         <div key={question.fieldName} className='space-y-2'>

--- a/components/project/ProjectBookingForm.tsx
+++ b/components/project/ProjectBookingForm.tsx
@@ -110,6 +110,21 @@ interface RFQAnswer {
   fieldType?: string;
 }
 
+interface VatAnswer {
+  fieldName: string;
+  value: string | number | boolean | string[];
+}
+
+interface VatPreviewDecision {
+  action: 'standard_rate' | 'reduced_rate' | 'rfq';
+  country: string;
+  standardRate: number;
+  appliedRate: number;
+  reducedRate?: number;
+  reverseCharge: boolean;
+  explanation?: string;
+}
+
 interface BlockedRange {
   startDate: string;
   endDate: string;
@@ -298,6 +313,8 @@ export default function ProjectBookingForm({
   } | null>(null);
   const [loadingScheduleWindow, setLoadingScheduleWindow] = useState(false);
   const [rfqAnswers, setRFQAnswers] = useState<RFQAnswer[]>([]);
+  const [vatAnswers, setVatAnswers] = useState<Record<string, VatAnswer>>({});
+  const [vatPreview, setVatPreview] = useState<VatPreviewDecision | null>(null);
   const [uploadingQuestionIndexes, setUploadingQuestionIndexes] = useState<Set<number>>(new Set());
   const [selectedExtraOptions, setSelectedExtraOptions] = useState<number[]>(
     []
@@ -313,6 +330,39 @@ export default function ProjectBookingForm({
       ? project.subprojects[selectedPackageIndex]
       : null;
   const isRfqPackage = selectedPackage?.pricing?.type === 'rfq';
+
+  // Best-effort VAT preview for the review step. Checkout always uses the
+  // backend-computed decision, so failures here are silently ignored.
+  useEffect(() => {
+    if (currentStep !== 4) return;
+    let cancelled = false;
+    (async () => {
+      try {
+        const response = await fetch(
+          `${process.env.NEXT_PUBLIC_BACKEND_URL}/api/bookings/vat-preview`,
+          {
+            method: 'POST',
+            credentials: 'include',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+              projectId: project._id,
+              serviceConfigurationId: project.serviceConfigurationId,
+              vatAnswers: Object.values(vatAnswers),
+            }),
+          }
+        );
+        const payload = await response.json();
+        if (!cancelled && response.ok && payload.success && payload.data) {
+          setVatPreview(payload.data);
+        }
+      } catch {
+        if (!cancelled) setVatPreview(null);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [currentStep, project._id, project.serviceConfigurationId, vatAnswers]);
 
   // Check if unit pricing - either explicit type or inferred from priceModel for old projects
   const isUnitPricing =
@@ -1870,6 +1920,10 @@ export default function ProjectBookingForm({
     });
   };
 
+  const handleVatAnswerChange = (fieldName: string, value: VatAnswer['value']) => {
+    setVatAnswers(prev => ({ ...prev, [fieldName]: { fieldName, value } }));
+  };
+
   const handleRFQAttachmentUpload = async (index: number, file: File | null) => {
     if (!file) return;
 
@@ -2030,6 +2084,20 @@ export default function ProjectBookingForm({
       }
     }
 
+    if (currentStep === 3 && project.vatManagement?.enabled) {
+      for (const question of project.vatManagement.reducedVatQuestions || []) {
+        const answer = vatAnswers[question.fieldName]?.value;
+        const isMissing =
+          answer === undefined ||
+          answer === '' ||
+          (Array.isArray(answer) && answer.length === 0);
+        if (question.isRequired && isMissing) {
+          toast.error(`Please answer: ${question.question}`);
+          return false;
+        }
+      }
+    }
+
     if (currentStep === 4) {
       if (useProfileAddress) {
         if (!hasProfileAddress) {
@@ -2143,6 +2211,8 @@ export default function ProjectBookingForm({
       const bookingData = {
         bookingType: 'project',
         projectId: project._id,
+        serviceConfigurationId: project.serviceConfigurationId,
+        vatAnswers: Object.values(vatAnswers),
         preferredStartDate: isRfqPackage ? undefined : selectedDate,
         preferredStartTime:
           !isRfqPackage && projectMode === 'hours' && selectedTime
@@ -2216,7 +2286,29 @@ export default function ProjectBookingForm({
         debugLog?.('[BOOKING] Response data:', data);
 
         if (response.ok && data.success) {
-          if (shouldPayAtCheckout && data.booking?._id) {
+          const returnedVatDecision = data.booking?.vatDecision;
+          const returnedStatus = data.booking?.status;
+
+          if (returnedVatDecision?.action === 'reduced_rate' && returnedVatDecision?.explanation) {
+            toast.success(returnedVatDecision.explanation);
+          }
+
+          if (returnedVatDecision?.action === 'rfq' && !returnedVatDecision?.reverseCharge) {
+            toast.info(returnedVatDecision.explanation || 'This VAT case requires quotation review. You can chat with the professional or proceed at the standard rate from your booking.');
+            // Only count as an RFQ completion when the package itself is RFQ;
+            // fixed-price bookings routed here are just pending VAT review.
+            if (selectedPackage?.pricing?.type === 'rfq') {
+              trackCompleteRfq(project, data.booking?._id, selectedPackageIndex);
+            }
+            if (data.booking?._id) {
+              router.replace(`/bookings/${data.booking._id}`);
+            } else {
+              router.replace('/dashboard');
+            }
+            return;
+          }
+
+          if (shouldPayAtCheckout && returnedStatus === 'quote_accepted' && data.booking?._id) {
             trackBeginCheckout(data.booking._id, {
               bookingNumber: data.booking.bookingNumber,
               payment: {
@@ -3804,6 +3896,87 @@ export default function ProjectBookingForm({
                 ))}
                 </>)}
 
+                {project.vatManagement?.enabled && project.vatManagement.reducedVatQuestions.length > 0 && (
+                  <div className='space-y-4 pt-4 border-t'>
+                    <div>
+                      <h2 className='text-xl font-semibold mb-2'>Reduced VAT questions</h2>
+                      <p className='text-gray-600 text-sm'>
+                        These answers determine whether a reduced VAT route can be applied.
+                      </p>
+                    </div>
+
+                    {project.vatManagement.reducedVatQuestions.map((question) => {
+                      const value = vatAnswers[question.fieldName]?.value;
+                      return (
+                        <div key={question.fieldName} className='space-y-2'>
+                          <Label htmlFor={`vat-${question.fieldName}`}>
+                            {question.question}
+                            {question.isRequired && <span className='text-red-500 ml-1'>*</span>}
+                          </Label>
+
+                          {question.answerType === 'number' && (
+                            <div className='flex gap-2'>
+                              <Input
+                                id={`vat-${question.fieldName}`}
+                                type='number'
+                                value={typeof value === 'number' || typeof value === 'string' ? value : ''}
+                                onChange={(e) => handleVatAnswerChange(question.fieldName, e.target.value ? Number(e.target.value) : '')}
+                              />
+                              {question.unit && (
+                                <span className='flex items-center rounded-md border bg-gray-50 px-3 text-sm text-gray-600'>
+                                  {question.unit}
+                                </span>
+                              )}
+                            </div>
+                          )}
+
+                          {question.answerType === 'yes_no' && (
+                            <RadioGroup
+                              value={value === true ? 'yes' : value === false ? 'no' : ''}
+                              onValueChange={(next) => handleVatAnswerChange(question.fieldName, next === 'yes')}
+                              className='flex gap-4'
+                            >
+                              <div className='flex items-center space-x-2'>
+                                <RadioGroupItem value='yes' id={`vat-${question.fieldName}-yes`} />
+                                <Label htmlFor={`vat-${question.fieldName}-yes`} className='font-normal'>Yes</Label>
+                              </div>
+                              <div className='flex items-center space-x-2'>
+                                <RadioGroupItem value='no' id={`vat-${question.fieldName}-no`} />
+                                <Label htmlFor={`vat-${question.fieldName}-no`} className='font-normal'>No</Label>
+                              </div>
+                            </RadioGroup>
+                          )}
+
+                          {question.answerType === 'checkboxes' && (
+                            <div className='space-y-2'>
+                              {(question.options || []).map((option) => {
+                                const selected = Array.isArray(value) && value.includes(option);
+                                return (
+                                  <label key={option} className='flex items-center gap-2 text-sm'>
+                                    <Checkbox
+                                      checked={selected}
+                                      onCheckedChange={(checked) => {
+                                        const current = Array.isArray(value) ? value : [];
+                                        handleVatAnswerChange(
+                                          question.fieldName,
+                                          checked
+                                            ? [...current, option]
+                                            : current.filter(item => item !== option)
+                                        );
+                                      }}
+                                    />
+                                    {option}
+                                  </label>
+                                );
+                              })}
+                            </div>
+                          )}
+                        </div>
+                      );
+                    })}
+                  </div>
+                )}
+
                 {/* Additional Notes */}
                 <div className='space-y-2 pt-4 border-t'>
                   <Label htmlFor='additional-notes'>
@@ -4219,7 +4392,7 @@ export default function ProjectBookingForm({
                       {finalDisplayTotal > 0 && (
                         <div className='flex justify-between items-center'>
                           <span className='text-lg font-bold text-gray-900'>
-                            Grand Total:
+                            Grand Total{vatPreview && !vatPreview.reverseCharge && vatPreview.action !== 'rfq' ? ' (excl. VAT)' : ''}:
                           </span>
                           <span className='text-2xl font-bold text-blue-600'>
                             {customerPricingReady ? (
@@ -4228,6 +4401,51 @@ export default function ProjectBookingForm({
                               <span className='inline-block h-7 w-28 animate-pulse rounded bg-gray-200' aria-label='Loading total' />
                             )}
                           </span>
+                        </div>
+                      )}
+
+                      {/* Estimated VAT */}
+                      {finalDisplayTotal > 0 && vatPreview && !isRfqPackage && (
+                        <div className='space-y-1 pt-2 border-t border-blue-200 text-sm'>
+                          {vatPreview.action === 'rfq' && !vatPreview.reverseCharge ? (
+                            <p className='text-amber-700'>
+                              {vatPreview.explanation ||
+                                'Your answers require a VAT review. After submitting you can chat with the professional or proceed at the standard VAT rate.'}
+                            </p>
+                          ) : vatPreview.reverseCharge ? (
+                            <>
+                              <div className='flex justify-between text-gray-700'>
+                                <span>VAT (0% — reverse charge)</span>
+                                <span>{formatCurrency(0)}</span>
+                              </div>
+                              <p className='text-xs text-gray-600'>
+                                Intra-Community supply, VAT exempt under Article 39bis of the VAT Directive.
+                              </p>
+                            </>
+                          ) : (
+                            <>
+                              <div className='flex justify-between text-gray-700'>
+                                <span>
+                                  Estimated VAT ({vatPreview.appliedRate}%
+                                  {vatPreview.action === 'reduced_rate' ? ' reduced rate' : ''})
+                                </span>
+                                <span>
+                                  {formatCurrency(Math.round(finalDisplayTotal * vatPreview.appliedRate) / 100)}
+                                </span>
+                              </div>
+                              <div className='flex justify-between font-semibold text-gray-900'>
+                                <span>Estimated total incl. VAT</span>
+                                <span>
+                                  {formatCurrency(
+                                    Math.round(finalDisplayTotal * (100 + vatPreview.appliedRate)) / 100
+                                  )}
+                                </span>
+                              </div>
+                              {vatPreview.action === 'reduced_rate' && vatPreview.explanation && (
+                                <p className='text-xs text-green-700'>{vatPreview.explanation}</p>
+                              )}
+                            </>
+                          )}
                         </div>
                       )}
 

--- a/components/quotation/QuotationWizard.tsx
+++ b/components/quotation/QuotationWizard.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
@@ -11,7 +11,8 @@ import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group'
 import { Loader2, Plus, Trash2, Package, Clock, Shield, FileText, CreditCard } from 'lucide-react'
 import { toast } from 'sonner'
 import { getAuthToken } from '@/lib/utils'
-import type { QuoteVersion, QuoteMaterial, QuotationMilestone, QuotationWizardFormData } from '@/types/quotation'
+import type { QuoteVersion, QuoteMaterial, QuotationMilestone, QuotationPricingLine, QuotationWizardFormData } from '@/types/quotation'
+import { calculateVatTotalsFromPricingLines } from '@/lib/vatPricing'
 
 interface QuotationWizardProps {
   bookingId: string
@@ -22,7 +23,21 @@ interface QuotationWizardProps {
   onCancel: () => void
 }
 
+interface VatRateOption {
+  rate: number
+  country: string
+  label: string
+  reverseCharge: boolean
+  source: 'standard' | 'reduced' | 'b2b_exempt'
+}
+
 const EMPTY_MATERIAL: QuoteMaterial = { name: '', quantity: undefined, unit: '', description: '' }
+const createEmptyPricingLine = (vatRate = 21, vatCountry = 'BE'): QuotationPricingLine => ({
+  description: '',
+  price: 0,
+  vatRate,
+  vatCountry,
+})
 const EMPTY_MILESTONE: QuotationMilestone = {
   title: '',
   amount: 0,
@@ -42,6 +57,15 @@ const VALID_NON_FIRST_DUE_CONDITIONS = [
   'on_milestone_completion',
   'custom_date',
 ] as const satisfies ReadonlyArray<QuotationMilestone['dueCondition']>
+
+const FALLBACK_VAT_RATE_OPTIONS: VatRateOption[] = [0, 5, 5.5, 6, 8.1, 9, 9.5, 10, 12, 13.5, 19, 20, 21, 22, 23, 24, 25, 25.5, 27]
+  .map(rate => ({
+    rate,
+    country: 'BE',
+    label: `${rate}% VAT`,
+    reverseCharge: rate === 0,
+    source: rate === 0 ? 'b2b_exempt' : 'standard',
+  }))
 
 const coerceNonFirstDueCondition = (
   value: unknown
@@ -93,6 +117,9 @@ const getDefaultFormData = (existing?: QuoteVersion): QuotationWizardFormData =>
       materialsIncluded: existing.materialsIncluded,
       materials: existing.materials?.length ? [...existing.materials] : [{ ...EMPTY_MATERIAL }],
       description: existing.description,
+      pricingLines: existing.pricingLines?.length
+        ? existing.pricingLines.map(line => ({ ...line }))
+        : [{ description: existing.description || existing.scope, price: existing.totalAmount, vatRate: 21, vatCountry: 'BE' }],
       totalAmount: existing.totalAmount,
       currency: existing.currency || 'EUR',
       useMilestones: (existing.milestones?.length || 0) > 0,
@@ -132,6 +159,7 @@ const getDefaultFormData = (existing?: QuoteVersion): QuotationWizardFormData =>
     materialsIncluded: null,
     materials: [{ ...EMPTY_MATERIAL }],
     description: '',
+    pricingLines: [createEmptyPricingLine()],
     totalAmount: 0,
     currency: 'EUR',
     useMilestones: false,
@@ -148,6 +176,63 @@ const getDefaultFormData = (existing?: QuoteVersion): QuotationWizardFormData =>
 export default function QuotationWizard({ bookingId, existingVersion, isEditing, commissionPercent, onSuccess, onCancel }: QuotationWizardProps) {
   const [form, setForm] = useState<QuotationWizardFormData>(getDefaultFormData(existingVersion))
   const [submitting, setSubmitting] = useState(false)
+  const [vatRateOptions, setVatRateOptions] = useState<VatRateOption[]>([])
+
+  const effectiveVatRateOptions = useMemo(
+    () => vatRateOptions.length > 0 ? vatRateOptions : FALLBACK_VAT_RATE_OPTIONS,
+    [vatRateOptions],
+  )
+
+  const defaultVatOption = effectiveVatRateOptions[0] || FALLBACK_VAT_RATE_OPTIONS[0]
+
+  useEffect(() => {
+    let cancelled = false
+
+    const loadVatRateOptions = async () => {
+      try {
+        const token = getAuthToken()
+        const headers: Record<string, string> = { 'Content-Type': 'application/json' }
+        if (token) headers.Authorization = `Bearer ${token}`
+
+        const response = await fetch(
+          `${process.env.NEXT_PUBLIC_BACKEND_URL}/api/quotations/${bookingId}/vat-rates`,
+          {
+            method: 'GET',
+            headers,
+            credentials: 'include',
+          },
+        )
+        const data = await response.json()
+        if (!response.ok || !data?.success || !Array.isArray(data.data?.options)) {
+          return
+        }
+
+        if (!cancelled) {
+          setVatRateOptions(data.data.options)
+          const firstOption = data.data.options[0] as VatRateOption | undefined
+          if (!existingVersion && firstOption) {
+            setForm(prev => ({
+              ...prev,
+              pricingLines: prev.pricingLines.map(line => ({
+                ...line,
+                vatRate: firstOption.rate,
+                vatCountry: firstOption.country,
+                vatLabel: firstOption.label,
+              })),
+            }))
+          }
+        }
+      } catch (error) {
+        console.error('Failed to load quotation VAT options:', error)
+      }
+    }
+
+    void loadVatRateOptions()
+
+    return () => {
+      cancelled = true
+    }
+  }, [bookingId, existingVersion])
 
   const updateForm = <K extends keyof QuotationWizardFormData>(key: K, value: QuotationWizardFormData[K]) => {
     setForm(prev => ({ ...prev, [key]: value }))
@@ -160,6 +245,35 @@ export default function QuotationWizard({ bookingId, existingVersion, isEditing,
     const updated = [...form.materials]
     updated[index] = { ...updated[index], [field]: value }
     updateForm('materials', updated)
+  }
+
+  const pricingTotal = Math.round(form.pricingLines.reduce((sum, line) => sum + (Number(line.price) || 0), 0) * 100) / 100
+  const pricingVatTotals = useMemo(
+    () => calculateVatTotalsFromPricingLines(form.pricingLines),
+    [form.pricingLines]
+  )
+
+  const addPricingLine = () => updateForm('pricingLines', [
+    ...form.pricingLines,
+    createEmptyPricingLine(defaultVatOption.rate, defaultVatOption.country),
+  ])
+  const removePricingLine = (index: number) => updateForm('pricingLines', form.pricingLines.filter((_, i) => i !== index))
+  const updatePricingLine = (index: number, field: keyof QuotationPricingLine, value: string | number) => {
+    const updated = [...form.pricingLines]
+    updated[index] = { ...updated[index], [field]: value }
+    updateForm('pricingLines', updated)
+    updateForm('totalAmount', Math.round(updated.reduce((sum, line) => sum + (Number(line.price) || 0), 0) * 100) / 100)
+  }
+
+  const updatePricingLineVat = (index: number, option: VatRateOption) => {
+    const updated = [...form.pricingLines]
+    updated[index] = {
+      ...updated[index],
+      vatRate: option.rate,
+      vatCountry: option.country,
+      vatLabel: option.label,
+    }
+    updateForm('pricingLines', updated)
   }
 
   // Milestones helpers
@@ -182,7 +296,7 @@ export default function QuotationWizard({ bookingId, existingVersion, isEditing,
   }
 
   const milestoneSum = form.milestones.reduce((sum, m) => sum + (m.amount || 0), 0)
-  const milestoneSumMatches = !form.useMilestones || Math.abs(milestoneSum - form.totalAmount) < 0.01
+  const milestoneSumMatches = !form.useMilestones || Math.abs(milestoneSum - pricingTotal) < 0.01
 
   const handleSubmit = async () => {
     // Validation
@@ -198,7 +312,16 @@ export default function QuotationWizard({ bookingId, existingVersion, isEditing,
       toast.error('Please specify whether materials are included')
       return
     }
-    if (!form.totalAmount || form.totalAmount <= 0) {
+    const validPricingLines = form.pricingLines.filter(line => line.description.trim())
+    if (validPricingLines.length === 0) {
+      toast.error('Add at least one pricing line')
+      return
+    }
+    if (validPricingLines.some(line => !line.price || line.price <= 0)) {
+      toast.error('Each pricing line needs a price greater than 0')
+      return
+    }
+    if (!pricingTotal || pricingTotal <= 0) {
       toast.error('Total amount must be greater than 0')
       return
     }
@@ -209,7 +332,7 @@ export default function QuotationWizard({ bookingId, existingVersion, isEditing,
     if (form.useMilestones) {
       const validMilestones = form.milestones.filter(m => m.title.trim())
       const validSum = validMilestones.reduce((sum, m) => sum + (m.amount || 0), 0)
-      if (Math.abs(validSum - form.totalAmount) >= 0.01) {
+      if (Math.abs(validSum - pricingTotal) >= 0.01) {
         toast.error('Sum of milestone amounts must equal the total amount')
         return
       }
@@ -241,7 +364,8 @@ export default function QuotationWizard({ bookingId, existingVersion, isEditing,
         materialsIncluded: form.materialsIncluded,
         materials: form.materialsIncluded ? form.materials.filter(m => m.name.trim()) : [],
         description: form.description,
-        totalAmount: form.totalAmount,
+        pricingLines: validPricingLines,
+        totalAmount: pricingTotal,
         currency: form.currency,
         milestones: form.useMilestones ? form.milestones.filter(m => m.title.trim()) : [],
         preparationDuration: form.preparationDuration,
@@ -400,21 +524,70 @@ export default function QuotationWizard({ bookingId, existingVersion, isEditing,
         {/* Price */}
         <div>
           <Label className="text-sm font-medium flex items-center gap-1">
-            <CreditCard className="h-4 w-4" /> Total Amount (EUR) *
+            <CreditCard className="h-4 w-4" /> Pricing Lines *
           </Label>
-          <Input
-            type="number"
-            min={0}
-            step={0.01}
-            value={form.totalAmount || ''}
-            onChange={e => updateForm('totalAmount', parseFloat(e.target.value) || 0)}
-            placeholder="1500.00"
-            className="mt-1"
-          />
+          <div className="mt-2 space-y-3">
+            {form.pricingLines.map((line, index) => (
+              <div key={index} className="grid grid-cols-1 sm:grid-cols-[1fr_120px_150px_40px] gap-2 items-start">
+                <Input
+                  value={line.description}
+                  onChange={e => updatePricingLine(index, 'description', e.target.value)}
+                  placeholder="Description"
+                />
+                <Input
+                  type="number"
+                  min={0}
+                  step={0.01}
+                  value={line.price || ''}
+                  onChange={e => updatePricingLine(index, 'price', parseFloat(e.target.value) || 0)}
+                  placeholder="1500.00"
+                />
+                <Select
+                  value={`${line.vatCountry || defaultVatOption.country}:${line.vatRate}`}
+                  onValueChange={v => {
+                    const option = effectiveVatRateOptions.find(candidate => `${candidate.country}:${candidate.rate}` === v)
+                    if (option) updatePricingLineVat(index, option)
+                  }}
+                >
+                  <SelectTrigger>
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {effectiveVatRateOptions.map(option => (
+                      <SelectItem
+                        key={`${option.country}:${option.rate}:${option.source}`}
+                        value={`${option.country}:${option.rate}`}
+                      >
+                        {option.label}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+                <Button type="button" variant="ghost" size="icon" onClick={() => removePricingLine(index)} disabled={form.pricingLines.length === 1} className="text-red-500 hover:text-red-700">
+                  <Trash2 className="h-4 w-4" />
+                </Button>
+              </div>
+            ))}
+            <Button type="button" variant="outline" size="sm" onClick={addPricingLine}>
+              <Plus className="h-4 w-4 mr-1" /> Add Pricing Line
+            </Button>
+          </div>
 
-          {form.totalAmount > 0 && typeof commissionPercent === 'number' && commissionPercent > 0 && (
+          <div className="mt-2 space-y-1">
+            <p className="text-sm text-gray-600">
+              Net total: <span className="font-medium text-gray-800">EUR {pricingTotal.toFixed(2)}</span>
+            </p>
+            <p className="text-sm text-gray-600">
+              VAT: <span className="font-medium text-gray-800">EUR {pricingVatTotals.vatAmount.toFixed(2)}</span>
+            </p>
+            <p className="text-sm font-medium text-gray-700">
+              Total (incl. VAT): <span className="font-semibold text-gray-900">EUR {pricingVatTotals.total.toFixed(2)}</span>
+            </p>
+          </div>
+
+          {pricingVatTotals.total > 0 && typeof commissionPercent === 'number' && commissionPercent > 0 && (
             <p className="text-xs text-gray-500 mt-1">
-              Price shown to customer: <span className="font-semibold text-gray-700">EUR {(form.totalAmount * (1 + commissionPercent / 100)).toFixed(2)}</span>
+              Price shown to customer: <span className="font-semibold text-gray-700">EUR {(pricingVatTotals.total * (1 + commissionPercent / 100)).toFixed(2)}</span>
               <span className="text-gray-400 ml-1">({commissionPercent}% commission included)</span>
             </p>
           )}
@@ -495,7 +668,7 @@ export default function QuotationWizard({ bookingId, existingVersion, isEditing,
                 <Plus className="h-4 w-4 mr-1" /> Add Milestone
               </Button>
               <div className={`text-xs font-medium ${milestoneSumMatches ? 'text-green-600' : 'text-red-600'}`}>
-                Milestone total: EUR {milestoneSum.toFixed(2)} / {form.totalAmount.toFixed(2)}
+                Milestone total: EUR {milestoneSum.toFixed(2)} / {pricingTotal.toFixed(2)}
                 {!milestoneSumMatches && ' (must match)'}
               </div>
             </div>

--- a/components/quotation/QuotationWizard.tsx
+++ b/components/quotation/QuotationWizard.tsx
@@ -58,14 +58,13 @@ const VALID_NON_FIRST_DUE_CONDITIONS = [
   'custom_date',
 ] as const satisfies ReadonlyArray<QuotationMilestone['dueCondition']>
 
-const FALLBACK_VAT_RATE_OPTIONS: VatRateOption[] = [0, 5, 5.5, 6, 8.1, 9, 9.5, 10, 12, 13.5, 19, 20, 21, 22, 23, 24, 25, 25.5, 27]
-  .map(rate => ({
-    rate,
-    country: 'BE',
-    label: `${rate}% VAT`,
-    reverseCharge: rate === 0,
-    source: rate === 0 ? 'b2b_exempt' : 'standard',
-  }))
+const FALLBACK_VAT_RATE_OPTIONS: VatRateOption[] = [{
+  rate: 21,
+  country: 'BE',
+  label: '21% standard VAT',
+  reverseCharge: false,
+  source: 'standard',
+}]
 
 const coerceNonFirstDueCondition = (
   value: unknown
@@ -247,10 +246,16 @@ export default function QuotationWizard({ bookingId, existingVersion, isEditing,
     updateForm('materials', updated)
   }
 
-  const pricingTotal = Math.round(form.pricingLines.reduce((sum, line) => sum + (Number(line.price) || 0), 0) * 100) / 100
+  const validPricingLinesForTotal = useMemo(
+    () => form.pricingLines.filter(line => line.description.trim()),
+    [form.pricingLines],
+  )
+  const pricingTotal = Math.round(
+    validPricingLinesForTotal.reduce((sum, line) => sum + (Number(line.price) || 0), 0) * 100
+  ) / 100
   const pricingVatTotals = useMemo(
-    () => calculateVatTotalsFromPricingLines(form.pricingLines),
-    [form.pricingLines]
+    () => calculateVatTotalsFromPricingLines(validPricingLinesForTotal),
+    [validPricingLinesForTotal],
   )
 
   const addPricingLine = () => updateForm('pricingLines', [
@@ -262,7 +267,12 @@ export default function QuotationWizard({ bookingId, existingVersion, isEditing,
     const updated = [...form.pricingLines]
     updated[index] = { ...updated[index], [field]: value }
     updateForm('pricingLines', updated)
-    updateForm('totalAmount', Math.round(updated.reduce((sum, line) => sum + (Number(line.price) || 0), 0) * 100) / 100)
+    const nextValidTotal = Math.round(
+      updated
+        .filter(line => line.description.trim())
+        .reduce((sum, line) => sum + (Number(line.price) || 0), 0) * 100
+    ) / 100
+    updateForm('totalAmount', nextValidTotal)
   }
 
   const updatePricingLineVat = (index: number, option: VatRateOption) => {
@@ -312,7 +322,7 @@ export default function QuotationWizard({ bookingId, existingVersion, isEditing,
       toast.error('Please specify whether materials are included')
       return
     }
-    const validPricingLines = form.pricingLines.filter(line => line.description.trim())
+    const validPricingLines = validPricingLinesForTotal
     if (validPricingLines.length === 0) {
       toast.error('Add at least one pricing line')
       return

--- a/lib/vatPricing.ts
+++ b/lib/vatPricing.ts
@@ -37,9 +37,11 @@ export const calculateVatTotalsFromPricingLines = (
   lines: Array<Pick<QuotationPricingLine, 'price' | 'vatRate'>>,
   mapNetAmount?: (netAmount: number) => number
 ): VatPricingTotals => {
-  const validLines = lines.filter(
-    (line) => Number.isFinite(Number(line.price)) && Number(line.price) > 0
-  )
+  const validLines = lines.filter((line) => {
+    const price = Number(line.price)
+    const vatRate = Number(line.vatRate)
+    return Number.isFinite(price) && price > 0 && Number.isFinite(vatRate) && vatRate >= 0 && vatRate <= 100
+  })
 
   if (validLines.length === 0) {
     return { netAmount: 0, vatAmount: 0, total: 0 }
@@ -51,7 +53,7 @@ export const calculateVatTotalsFromPricingLines = (
   for (const line of validLines) {
     const rawNet = Number(line.price)
     const lineNet = mapNetAmount ? mapNetAmount(rawNet) : rawNet
-    const lineVat = (lineNet * (Number(line.vatRate) || 0)) / 100
+    const lineVat = (lineNet * Number(line.vatRate)) / 100
     netAmount += lineNet
     vatAmount += lineVat
   }

--- a/lib/vatPricing.ts
+++ b/lib/vatPricing.ts
@@ -1,0 +1,100 @@
+import type { QuotationMilestone, QuotationPricingLine } from '@/types/quotation'
+
+export interface VatPricingTotals {
+  netAmount: number
+  vatAmount: number
+  total: number
+}
+
+export interface VatQuoteVersionLike {
+  scope?: string
+  description?: string
+  totalAmount?: number
+  pricingLines?: Array<Pick<QuotationPricingLine, 'description' | 'price' | 'vatRate'>>
+  milestones?: Array<Pick<QuotationMilestone, 'amount'>>
+}
+
+const roundMoney = (value: number): number => Math.round((value + Number.EPSILON) * 100) / 100
+
+const allocateRoundedAmounts = (amounts: number[], targetTotal: number): number[] => {
+  const sourceTotal = amounts.reduce((sum, amount) => sum + amount, 0)
+  if (!(sourceTotal > 0) || !(targetTotal > 0)) {
+    return amounts.map(() => 0)
+  }
+
+  let allocated = 0
+  return amounts.map((amount, index) => {
+    if (index === amounts.length - 1) {
+      return roundMoney(targetTotal - allocated)
+    }
+    const share = roundMoney((amount / sourceTotal) * targetTotal)
+    allocated = roundMoney(allocated + share)
+    return share
+  })
+}
+
+export const calculateVatTotalsFromPricingLines = (
+  lines: Array<Pick<QuotationPricingLine, 'price' | 'vatRate'>>,
+  mapNetAmount?: (netAmount: number) => number
+): VatPricingTotals => {
+  const validLines = lines.filter(
+    (line) => Number.isFinite(Number(line.price)) && Number(line.price) > 0
+  )
+
+  if (validLines.length === 0) {
+    return { netAmount: 0, vatAmount: 0, total: 0 }
+  }
+
+  let netAmount = 0
+  let vatAmount = 0
+
+  for (const line of validLines) {
+    const rawNet = Number(line.price)
+    const lineNet = mapNetAmount ? mapNetAmount(rawNet) : rawNet
+    const lineVat = (lineNet * (Number(line.vatRate) || 0)) / 100
+    netAmount += lineNet
+    vatAmount += lineVat
+  }
+
+  netAmount = roundMoney(netAmount)
+  vatAmount = roundMoney(vatAmount)
+
+  return {
+    netAmount,
+    vatAmount,
+    total: roundMoney(netAmount + vatAmount),
+  }
+}
+
+export const getQuoteVersionPricingLines = (
+  version: VatQuoteVersionLike | null | undefined
+): Array<Pick<QuotationPricingLine, 'description' | 'price' | 'vatRate'>> => {
+  if (!version) return []
+  return version.pricingLines?.length
+    ? version.pricingLines
+    : [{ description: version.description || version.scope || 'Quote', price: version.totalAmount || 0, vatRate: 0 }]
+}
+
+export const calculateQuoteVersionVatTotals = (
+  version: VatQuoteVersionLike | null | undefined,
+  mapNetAmount?: (netAmount: number) => number
+): VatPricingTotals => calculateVatTotalsFromPricingLines(
+  getQuoteVersionPricingLines(version),
+  mapNetAmount
+)
+
+export const calculateMilestoneGrossAmounts = (
+  version: VatQuoteVersionLike | null | undefined,
+  mapNetAmount?: (netAmount: number) => number
+): number[] => {
+  const milestones = version?.milestones || []
+  if (milestones.length === 0) return []
+
+  const milestoneNetAmounts = milestones.map((milestone) => {
+    const netAmount = Number(milestone.amount) || 0
+    return mapNetAmount ? mapNetAmount(netAmount) : netAmount
+  })
+  const quoteTotals = calculateQuoteVersionVatTotals(version, mapNetAmount)
+
+  return allocateRoundedAmounts(milestoneNetAmounts, quoteTotals.total)
+}

--- a/lib/vatPricing.ts
+++ b/lib/vatPricing.ts
@@ -66,13 +66,20 @@ export const calculateVatTotalsFromPricingLines = (
   }
 }
 
+/** Legacy quotes without granular pricingLines use a single synthetic line at 0% VAT. */
 export const getQuoteVersionPricingLines = (
   version: VatQuoteVersionLike | null | undefined
 ): Array<Pick<QuotationPricingLine, 'description' | 'price' | 'vatRate'>> => {
   if (!version) return []
-  return version.pricingLines?.length
-    ? version.pricingLines
-    : [{ description: version.description || version.scope || 'Quote', price: version.totalAmount || 0, vatRate: 0 }]
+  if (version.pricingLines?.length) {
+    return version.pricingLines
+  }
+  // Backward compatibility: pre-line-item quotes only expose totalAmount.
+  return [{
+    description: version.description || version.scope || 'Quote',
+    price: version.totalAmount || 0,
+    vatRate: 0,
+  }]
 }
 
 export const calculateQuoteVersionVatTotals = (

--- a/types/project.ts
+++ b/types/project.ts
@@ -103,6 +103,7 @@ export interface ProjectDto {
   description: string
   category: string
   service: string
+  serviceConfigurationId?: string
   priceModel?: string
   timeMode?: "hours" | "days" | "mixed"
   preparationDuration?: {
@@ -173,6 +174,18 @@ export interface ProjectDto {
     isRequired: boolean
     professionalAttachments?: ProjectAttachmentRef[]
   }>
+  vatManagement?: {
+    enabled: boolean
+    rateRuleGroup?: string
+    reducedVatQuestions: Array<{
+      question: string
+      fieldName: string
+      answerType: "number" | "yes_no" | "checkboxes"
+      unit?: string
+      options?: string[]
+      isRequired: boolean
+    }>
+  }
   customerPresence?: string
   termsConditions?: Array<{
     name: string

--- a/types/quotation.ts
+++ b/types/quotation.ts
@@ -1,3 +1,9 @@
+export interface QuotationPricingLine {
+  description: string
+  price: number
+  vatRate: number
+}
+
 export interface QuotationMilestone {
   title: string
   amount: number

--- a/types/quotation.ts
+++ b/types/quotation.ts
@@ -30,6 +30,14 @@ export interface QuoteMaterial {
   description?: string
 }
 
+export interface QuotationPricingLine {
+  description: string
+  price: number
+  vatRate: number
+  vatCountry?: string
+  vatLabel?: string
+}
+
 export interface QuoteVersion {
   version: number
   quotationNumber: string
@@ -38,6 +46,7 @@ export interface QuoteVersion {
   materialsIncluded: boolean
   materials?: QuoteMaterial[]
   description: string
+  pricingLines?: QuotationPricingLine[]
   totalAmount: number
   currency: string
   milestones?: QuotationMilestone[]
@@ -55,6 +64,7 @@ export interface QuotationWizardFormData {
   materialsIncluded: boolean | null
   materials: QuoteMaterial[]
   description: string
+  pricingLines: QuotationPricingLine[]
   totalAmount: number
   currency: string
   useMilestones: boolean


### PR DESCRIPTION
## Summary
- Collects VAT answers in the booking wizard with preview and validation.
- Adds multi-line VAT pricing to the quotation wizard.
- Surfaces VAT decision states on booking detail.

## Stack
- Depends on phase 1 (#219)
- Phase 3 → stacks on this PR
- Phase 4 → stacks on phase 3

## Paired backend PR
fixera-server phase 2 (#189)

## Test plan
- [x] `npm run build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added VAT-aware booking, quotation, and service configuration workflows.
  * Booking and checkout screens now show estimated VAT, reverse-charge messaging, and clearer “incl. VAT/excl. VAT” pricing.
  * Quotation pricing now supports multiple line items with per-line VAT selections and updated milestone totals.
  * Service configuration now includes editable VAT question and rule setup for tailored VAT handling.

* **Bug Fixes**
  * Improved payment breakdowns with invoice, credit note, and download details.
  * Milestone progress and pricing summaries now reflect more accurate totals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->