### PR TITLE
fix: use fixeraManaged for renovation planning (Phase-1)

### DIFF
--- a/app/(pages)/admin/projects/approval/page.tsx
+++ b/app/(pages)/admin/projects/approval/page.tsx
@@ -196,8 +196,6 @@ interface Project {
     resources?: string[]
   }
   renovationPlanning?: {
-    fixtractManaged?: boolean
-    /** Legacy pre-rebrand field; prefer fixtractManaged */
     fixeraManaged?: boolean
     resources?: string[]
   }
@@ -961,7 +959,7 @@ export default function ProjectApprovalPage() {
                         )}
 
                         {/* Renovation Planning */}
-                        {(selectedProject.renovationPlanning?.fixtractManaged ?? selectedProject.renovationPlanning?.fixeraManaged) && (
+                        {(selectedProject.renovationPlanning?.fixeraManaged) && (
                           <div>
                             <Label className="text-sm font-medium">Renovation Planning</Label>
                             <p className="text-sm text-gray-700 mt-1">

--- a/app/(pages)/professional/projects/[id]/page.tsx
+++ b/app/(pages)/professional/projects/[id]/page.tsx
@@ -60,8 +60,6 @@ interface IIntakeMeeting {
 }
 
 interface IRenovationPlanning {
-  fixtractManaged?: boolean
-  /** Legacy pre-rebrand field; prefer fixtractManaged */
   fixeraManaged?: boolean
   resources: string[]
 }
@@ -1366,7 +1364,7 @@ export default function ProjectDetailPage() {
                     </div>
                   )}
 
-                  {(project.renovationPlanning?.fixtractManaged ?? project.renovationPlanning?.fixeraManaged) && (
+                  {(project.renovationPlanning?.fixeraManaged) && (
                     <div>
                       <span className="font-medium text-gray-600 text-sm">Renovation Planning:</span>
                       <p className="text-sm">Fixtract Managed</p>

--- a/app/(pages)/projects/create/page.tsx
+++ b/app/(pages)/projects/create/page.tsx
@@ -136,8 +136,6 @@ interface ProjectData {
     resources: string[]
   }
   renovationPlanning?: {
-    fixtractManaged?: boolean
-    /** Legacy pre-rebrand field; prefer fixtractManaged */
     fixeraManaged?: boolean
     resources: string[]
   }
@@ -325,13 +323,10 @@ export default function ProjectCreatePage() {
             intakeMeeting: project.intakeMeeting || { enabled: false, resources: [] },
             renovationPlanning: project.renovationPlanning
               ? {
-                  fixtractManaged:
-                    project.renovationPlanning.fixtractManaged ??
-                    project.renovationPlanning.fixeraManaged ??
-                    false,
+                  fixeraManaged: project.renovationPlanning.fixeraManaged ?? false,
                   resources: project.renovationPlanning.resources || [],
                 }
-              : { fixtractManaged: false, resources: [] },
+              : { fixeraManaged: false, resources: [] },
             distance: project.distance || {
               address: '',
               useCompanyAddress: false,

--- a/components/professional/project-wizard/Step1BasicInfo.tsx
+++ b/components/professional/project-wizard/Step1BasicInfo.tsx
@@ -44,9 +44,7 @@ interface ProjectData {
     enabled: boolean
     resources: string[]
   }
-  renovationPlanning?: {
-    fixtractManaged?: boolean
-    /** Legacy pre-rebrand field; prefer fixtractManaged */
+    renovationPlanning?: {
     fixeraManaged?: boolean
     resources: string[]
   }
@@ -592,7 +590,7 @@ const Step1BasicInfo = forwardRef<Step1Ref, Step1Props>(({ data, onChange, onVal
     const updatedResources = current.includes(memberId)
       ? current.filter(id => id !== memberId)
       : [...current, memberId]
-    updateFormData({ renovationPlanning: { fixtractManaged: formData.renovationPlanning?.fixtractManaged ?? formData.renovationPlanning?.fixeraManaged ?? false, resources: updatedResources } })
+    updateFormData({ renovationPlanning: { fixeraManaged: formData.renovationPlanning?.fixeraManaged ?? false, resources: updatedResources } })
   }
 
   const handleImageUpload = (files: FileList | null) => {
@@ -1023,13 +1021,13 @@ const Step1BasicInfo = forwardRef<Step1Ref, Step1Props>(({ data, onChange, onVal
               <div className="flex items-center space-x-2">
                 <Checkbox
                   id="planningManaged"
-                  checked={formData.renovationPlanning?.fixtractManaged ?? formData.renovationPlanning?.fixeraManaged ?? false}
-                  onCheckedChange={(checked) => updateFormData({ renovationPlanning: { fixtractManaged: checked as boolean, resources: formData.renovationPlanning?.resources || [] } })}
+                  checked={formData.renovationPlanning?.fixeraManaged ?? false}
+                  onCheckedChange={(checked) => updateFormData({ renovationPlanning: { fixeraManaged: checked as boolean, resources: formData.renovationPlanning?.resources || [] } })}
                 />
                 <Label htmlFor="planningManaged" className="cursor-pointer">Fixtract-managed planning</Label>
               </div>
 
-              {(formData.renovationPlanning?.fixtractManaged ?? formData.renovationPlanning?.fixeraManaged) && (
+              {(formData.renovationPlanning?.fixeraManaged) && (
                 <div className="space-y-6">
                   {/* Planning Team Selection */}
                   <div className="space-y-3">


### PR DESCRIPTION
## Summary
- Keep the existing `renovationPlanning.fixeraManaged` DB/API field for Phase-1
- Remove frontend `fixtractManaged` dual-read/write so it matches backend (no virtual alias / no field rename)

## Test plan
- [ ] Project wizard toggle for Fixtract-managed planning still saves/loads
- [ ] Admin approval and professional project detail show renovation planning when `fixeraManaged` is true