### PR TITLE
feat(notifications): inbox dropdown and preference UX

### DIFF
--- a/app/(pages)/dashboard/page.tsx
+++ b/app/(pages)/dashboard/page.tsx
@@ -1048,11 +1048,13 @@ export default function DashboardPage() {
                       <button
                         type="button"
                         aria-label="What does Run Notification Reminders do?"
+                        aria-describedby="notif-reminders-help"
                         className="inline-flex rounded p-0.5 text-slate-400 hover:text-slate-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
                       >
                         <Info className="h-4 w-4" aria-hidden="true" />
                       </button>
                       <div
+                        id="notif-reminders-help"
                         role="tooltip"
                         className="absolute left-1/2 -translate-x-1/2 top-6 z-50 hidden group-hover:block group-focus-within:block w-72 rounded-lg border bg-white p-3 text-xs text-slate-600 shadow-lg"
                       >
@@ -1080,11 +1082,13 @@ export default function DashboardPage() {
                       <button
                         type="button"
                         aria-label="What does Run Completion Auto-Accept do?"
+                        aria-describedby="completion-autoaccept-help"
                         className="inline-flex rounded p-0.5 text-slate-400 hover:text-slate-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
                       >
                         <Info className="h-4 w-4" aria-hidden="true" />
                       </button>
                       <div
+                        id="completion-autoaccept-help"
                         role="tooltip"
                         className="absolute right-0 top-6 z-50 hidden group-hover:block group-focus-within:block w-72 rounded-lg border bg-white p-3 text-xs text-slate-600 shadow-lg"
                       >

--- a/app/(pages)/dashboard/page.tsx
+++ b/app/(pages)/dashboard/page.tsx
@@ -132,6 +132,8 @@ export default function DashboardPage() {
   const [warrantyAnalytics, setWarrantyAnalytics] = useState<WarrantyAnalytics | null>(null)
   const [isRunningWarrantyCheck, setIsRunningWarrantyCheck] = useState(false)
   const [isRunningRfqCheck, setIsRunningRfqCheck] = useState(false)
+  const [isRunningNotifReminders, setIsRunningNotifReminders] = useState(false)
+  const [isRunningAutoAccept, setIsRunningAutoAccept] = useState(false)
   const [isRecalculatingProfessionalLevels, setIsRecalculatingProfessionalLevels] = useState(false)
   const [isLoadingStats, setIsLoadingStats] = useState(false)
   const [bookings, setBookings] = useState<Booking[]>([])
@@ -313,9 +315,21 @@ export default function DashboardPage() {
     }
   }
 
-  const runSchedulerCheck = async (type: 'warranty' | 'rfq') => {
-    const setLoading = type === 'warranty' ? setIsRunningWarrantyCheck : setIsRunningRfqCheck
-    const endpoint = type === 'warranty' ? 'run-warranty-checks' : 'run-rfq-checks'
+  const runSchedulerCheck = async (type: 'warranty' | 'rfq' | 'notif' | 'autoaccept') => {
+    const loadingMap = {
+      warranty: setIsRunningWarrantyCheck,
+      rfq: setIsRunningRfqCheck,
+      notif: setIsRunningNotifReminders,
+      autoaccept: setIsRunningAutoAccept,
+    } as const
+    const endpointMap = {
+      warranty: 'run-warranty-checks',
+      rfq: 'run-rfq-checks',
+      notif: 'run-notification-reminders',
+      autoaccept: 'run-completion-auto-accept',
+    } as const
+    const setLoading = loadingMap[type]
+    const endpoint = endpointMap[type]
     setLoading(true)
     try {
       const token = getAuthToken()
@@ -336,13 +350,27 @@ export default function DashboardPage() {
         if (d.closed) parts.push(`${d.closed} auto-closed`)
         if (d.errors?.length) parts.push(`${d.errors.length} error(s)`)
         toast.success(parts.length ? `Warranty: ${parts.join(', ')}` : 'No overdue warranty claims found')
-      } else {
+      } else if (type === 'rfq') {
         const parts: string[] = []
         if (d.cancelled) parts.push(`${d.cancelled} cancelled`)
         if (d.remindersSent) parts.push(`${d.remindersSent} reminder(s) sent`)
         if (d.expiredQuotationsFound) parts.push(`${d.expiredQuotationsFound} expired quotation(s)`)
         if (d.errors?.length) parts.push(`${d.errors.length} error(s)`)
         toast.success(parts.length ? `RFQ: ${parts.join(', ')}` : 'No overdue RFQ deadlines found')
+      } else if (type === 'notif') {
+        const parts: string[] = []
+        for (const [key, val] of Object.entries(d)) {
+          if (key === 'errors') continue
+          if (typeof val === 'number' && val > 0) parts.push(`${key}: ${val}`)
+        }
+        if (d.errors?.length) parts.push(`${d.errors.length} error(s)`)
+        toast.success(parts.length ? `Reminders — ${parts.join(', ')}` : 'No notification reminders due')
+      } else {
+        const parts: string[] = []
+        if (d.autoAccepted) parts.push(`${d.autoAccepted} auto-accepted`)
+        if (d.skipped) parts.push(`${d.skipped} skipped`)
+        if (d.errors?.length) parts.push(`${d.errors.length} error(s)`)
+        toast.success(parts.length ? `Auto-accept — ${parts.join(', ')}` : 'No completions to auto-accept')
       }
       await fetchAdminData()
     } catch (err) {
@@ -957,7 +985,8 @@ export default function DashboardPage() {
                   </CardTitle>
                   <CardDescription>Manually trigger background checks that process overdue items. Safe to run anytime — only acts on items that are actually overdue.</CardDescription>
                 </CardHeader>
-                <CardContent className="flex flex-col sm:flex-row gap-4">
+                <CardContent className="flex flex-col gap-4">
+                  <div className="flex flex-col sm:flex-row gap-4">
                   <div className="flex-1 flex items-center gap-1.5">
                     <Button
                       variant="outline"
@@ -1002,6 +1031,54 @@ export default function DashboardPage() {
                         <p className="mt-2 text-slate-400">Safe to run anytime — only acts on overdue items.</p>
                       </div>
                     </div>
+                  </div>
+                  </div>
+                  <div className="flex flex-col sm:flex-row gap-4">
+                  <div className="flex-1 flex items-center gap-1.5">
+                    <Button
+                      variant="outline"
+                      onClick={() => runSchedulerCheck('notif')}
+                      disabled={isRunningNotifReminders}
+                      className="flex-1 border-blue-300 text-blue-700 hover:bg-blue-50"
+                    >
+                      {isRunningNotifReminders ? <Loader2 className="h-4 w-4 mr-2 animate-spin" /> : <Play className="h-4 w-4 mr-2" />}
+                      Run Notification Reminders
+                    </Button>
+                    <div className="relative group">
+                      <Info className="h-4 w-4 text-slate-400 cursor-help" />
+                      <div className="absolute left-1/2 -translate-x-1/2 top-6 z-50 hidden group-hover:block w-72 rounded-lg border bg-white p-3 text-xs text-slate-600 shadow-lg">
+                        <p className="font-semibold text-slate-800 mb-1">What does this do?</p>
+                        <ul className="space-y-1 list-disc pl-3">
+                          <li>Sends 3-day nudges for RFQ, reschedule, refund, completion, and not-started bookings</li>
+                          <li>Review reminders at 10 and 20 days; unread chat after 24h</li>
+                          <li>ID expiry warnings within 30 days, then every 15 days</li>
+                        </ul>
+                        <p className="mt-2 text-slate-400">Safe to run anytime — tracking fields prevent duplicates.</p>
+                      </div>
+                    </div>
+                  </div>
+                  <div className="flex-1 flex items-center gap-1.5">
+                    <Button
+                      variant="outline"
+                      onClick={() => runSchedulerCheck('autoaccept')}
+                      disabled={isRunningAutoAccept}
+                      className="flex-1 border-emerald-300 text-emerald-700 hover:bg-emerald-50"
+                    >
+                      {isRunningAutoAccept ? <Loader2 className="h-4 w-4 mr-2 animate-spin" /> : <Play className="h-4 w-4 mr-2" />}
+                      Run Completion Auto-Accept
+                    </Button>
+                    <div className="relative group">
+                      <Info className="h-4 w-4 text-slate-400 cursor-help" />
+                      <div className="absolute right-0 top-6 z-50 hidden group-hover:block w-72 rounded-lg border bg-white p-3 text-xs text-slate-600 shadow-lg">
+                        <p className="font-semibold text-slate-800 mb-1">What does this do?</p>
+                        <ul className="space-y-1 list-disc pl-3">
+                          <li>Auto-accepts professional completion requests after 10 days with no customer response</li>
+                          <li>Skips bookings with unpaid milestones or unpaid extra costs</li>
+                        </ul>
+                        <p className="mt-2 text-slate-400">Safe to run anytime — only acts on eligible bookings.</p>
+                      </div>
+                    </div>
+                  </div>
                   </div>
                 </CardContent>
               </Card>

--- a/app/(pages)/dashboard/page.tsx
+++ b/app/(pages)/dashboard/page.tsx
@@ -1045,8 +1045,17 @@ export default function DashboardPage() {
                       Run Notification Reminders
                     </Button>
                     <div className="relative group">
-                      <Info className="h-4 w-4 text-slate-400 cursor-help" />
-                      <div className="absolute left-1/2 -translate-x-1/2 top-6 z-50 hidden group-hover:block w-72 rounded-lg border bg-white p-3 text-xs text-slate-600 shadow-lg">
+                      <button
+                        type="button"
+                        aria-label="What does Run Notification Reminders do?"
+                        className="inline-flex rounded p-0.5 text-slate-400 hover:text-slate-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+                      >
+                        <Info className="h-4 w-4" aria-hidden="true" />
+                      </button>
+                      <div
+                        role="tooltip"
+                        className="absolute left-1/2 -translate-x-1/2 top-6 z-50 hidden group-hover:block group-focus-within:block w-72 rounded-lg border bg-white p-3 text-xs text-slate-600 shadow-lg"
+                      >
                         <p className="font-semibold text-slate-800 mb-1">What does this do?</p>
                         <ul className="space-y-1 list-disc pl-3">
                           <li>Sends 3-day nudges for RFQ, reschedule, refund, completion, and not-started bookings</li>
@@ -1068,8 +1077,17 @@ export default function DashboardPage() {
                       Run Completion Auto-Accept
                     </Button>
                     <div className="relative group">
-                      <Info className="h-4 w-4 text-slate-400 cursor-help" />
-                      <div className="absolute right-0 top-6 z-50 hidden group-hover:block w-72 rounded-lg border bg-white p-3 text-xs text-slate-600 shadow-lg">
+                      <button
+                        type="button"
+                        aria-label="What does Run Completion Auto-Accept do?"
+                        className="inline-flex rounded p-0.5 text-slate-400 hover:text-slate-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+                      >
+                        <Info className="h-4 w-4" aria-hidden="true" />
+                      </button>
+                      <div
+                        role="tooltip"
+                        className="absolute right-0 top-6 z-50 hidden group-hover:block group-focus-within:block w-72 rounded-lg border bg-white p-3 text-xs text-slate-600 shadow-lg"
+                      >
                         <p className="font-semibold text-slate-800 mb-1">What does this do?</p>
                         <ul className="space-y-1 list-disc pl-3">
                           <li>Auto-accepts professional completion requests after 10 days with no customer response</li>

--- a/components/notifications/FCMLayoutWrapper.tsx
+++ b/components/notifications/FCMLayoutWrapper.tsx
@@ -3,6 +3,7 @@
 import React from 'react';
 import { useAuth } from '@/contexts/AuthContext';
 import { FCMProvider } from '@/contexts/FCMProvider';
+import { NotificationInboxProvider } from '@/contexts/NotificationInboxProvider';
 import NotificationPermissionPrompt from '@/components/notifications/NotificationPermissionPrompt';
 
 /**
@@ -11,7 +12,8 @@ import NotificationPermissionPrompt from '@/components/notifications/Notificatio
  * A thin client-component bridge that:
  *  1. Reads the current auth state from AuthContext
  *  2. Mounts FCMProvider (passes isAuthenticated so it knows when to init)
- *  3. Renders the non-intrusive permission prompt for authenticated users
+ *  3. Mounts NotificationInboxProvider for the bell dropdown
+ *  4. Renders the non-intrusive permission prompt for authenticated users
  *
  * Must be a child of <AuthProvider>.
  */
@@ -20,8 +22,10 @@ const FCMLayoutWrapper: React.FC<{ children: React.ReactNode }> = ({ children })
 
   return (
     <FCMProvider isAuthenticated={isAuthenticated}>
-      {children}
-      {isAuthenticated && <NotificationPermissionPrompt />}
+      <NotificationInboxProvider isAuthenticated={isAuthenticated}>
+        {children}
+        {isAuthenticated && <NotificationPermissionPrompt />}
+      </NotificationInboxProvider>
     </FCMProvider>
   );
 };

--- a/components/notifications/NotificationBell.tsx
+++ b/components/notifications/NotificationBell.tsx
@@ -2,37 +2,139 @@
 
 import React from 'react';
 import Link from 'next/link';
-import { Bell } from 'lucide-react';
-import { useFCM } from '@/contexts/FCMProvider';
+import { useRouter } from 'next/navigation';
+import { Bell, CheckCheck, Settings } from 'lucide-react';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import { useNotificationInbox } from '@/contexts/NotificationInboxProvider';
+
+function relativeTime(iso: string): string {
+  const then = new Date(iso).getTime();
+  if (Number.isNaN(then)) return '';
+  const diffSec = Math.round((Date.now() - then) / 1000);
+  if (diffSec < 60) return 'just now';
+  const diffMin = Math.round(diffSec / 60);
+  if (diffMin < 60) return `${diffMin}m ago`;
+  const diffHr = Math.round(diffMin / 60);
+  if (diffHr < 24) return `${diffHr}h ago`;
+  const diffDay = Math.round(diffHr / 24);
+  if (diffDay < 7) return `${diffDay}d ago`;
+  return new Date(iso).toLocaleDateString();
+}
 
 interface NotificationBellProps {
   className?: string;
 }
 
 /**
- * Notification bell icon with a badge showing unread push count.
- * Clicking it opens the notification settings page.
+ * Notification bell with dropdown inbox of received notifications.
  */
 const NotificationBell: React.FC<NotificationBellProps> = ({ className = '' }) => {
-  const { unreadPushCount } = useFCM();
+  const router = useRouter();
+  const { items, unreadCount, loading, markRead, markAllRead, refresh } = useNotificationInbox();
 
   return (
-    <Link
-      id="notification-bell"
-      href="/profile?tab=notifications"
-      aria-label={`Notifications${unreadPushCount > 0 ? ` (${unreadPushCount} unread)` : ''}`}
-      className={`relative inline-flex items-center justify-center h-8 w-8 rounded-full text-gray-600 hover:text-blue-600 hover:bg-gray-100 transition-colors ${className}`}
+    <DropdownMenu
+      onOpenChange={(open) => {
+        if (open) void refresh();
+      }}
     >
-      <Bell className="h-5 w-5" />
-      {unreadPushCount > 0 && (
-        <span
-          aria-hidden="true"
-          className="absolute -top-0.5 -right-0.5 inline-flex h-4 min-w-4 items-center justify-center rounded-full bg-blue-600 px-1 text-[10px] font-bold text-white animate-pulse"
+      <DropdownMenuTrigger asChild>
+        <button
+          id="notification-bell"
+          type="button"
+          aria-label={`Notifications${unreadCount > 0 ? ` (${unreadCount} unread)` : ''}`}
+          className={`relative inline-flex items-center justify-center h-8 w-8 rounded-full text-gray-600 hover:text-blue-600 hover:bg-gray-100 transition-colors ${className}`}
         >
-          {unreadPushCount > 99 ? '99+' : unreadPushCount}
-        </span>
-      )}
-    </Link>
+          <Bell className="h-5 w-5" />
+          {unreadCount > 0 && (
+            <span
+              aria-hidden="true"
+              className="absolute -top-0.5 -right-0.5 inline-flex h-4 min-w-4 items-center justify-center rounded-full bg-red-500 px-1 text-[10px] font-bold text-white"
+            >
+              {unreadCount > 99 ? '99+' : unreadCount}
+            </span>
+          )}
+        </button>
+      </DropdownMenuTrigger>
+
+      <DropdownMenuContent className="w-80 sm:w-96 p-0" align="end" forceMount>
+        <div className="flex items-center justify-between px-3 py-2.5">
+          <DropdownMenuLabel className="p-0 text-sm font-semibold">Notifications</DropdownMenuLabel>
+          {unreadCount > 0 && (
+            <button
+              type="button"
+              onClick={() => { void markAllRead(); }}
+              className="inline-flex items-center gap-1 text-xs text-blue-600 hover:text-blue-700 font-medium"
+            >
+              <CheckCheck className="h-3.5 w-3.5" />
+              Mark all read
+            </button>
+          )}
+        </div>
+        <DropdownMenuSeparator className="my-0" />
+
+        <div className="max-h-80 overflow-y-auto">
+          {loading && items.length === 0 && (
+            <p className="px-3 py-6 text-center text-sm text-gray-400">Loading…</p>
+          )}
+          {!loading && items.length === 0 && (
+            <p className="px-3 py-6 text-center text-sm text-gray-400">No notifications yet</p>
+          )}
+          {items.map((n) => {
+            const unread = !n.readAt;
+            return (
+              <DropdownMenuItem
+                key={n.id}
+                className={`flex flex-col items-start gap-0.5 px-3 py-2.5 cursor-pointer rounded-none focus:bg-gray-50 ${
+                  unread ? 'bg-blue-50/60' : ''
+                }`}
+                onSelect={(e) => {
+                  e.preventDefault();
+                  if (unread) void markRead(n.id);
+                  if (n.clickUrl) {
+                    try {
+                      const url = new URL(n.clickUrl, window.location.origin);
+                      if (url.origin === window.location.origin) {
+                        router.push(`${url.pathname}${url.search}${url.hash}`);
+                      } else {
+                        window.location.href = n.clickUrl;
+                      }
+                    } catch {
+                      router.push(n.clickUrl);
+                    }
+                  }
+                }}
+              >
+                <div className="flex w-full items-start justify-between gap-2">
+                  <p className={`text-sm leading-snug ${unread ? 'font-semibold text-gray-900' : 'font-medium text-gray-800'}`}>
+                    {n.title}
+                  </p>
+                  <span className="shrink-0 text-[10px] text-gray-400 mt-0.5">
+                    {relativeTime(n.createdAt)}
+                  </span>
+                </div>
+                <p className="text-xs text-gray-500 line-clamp-2 w-full">{n.body}</p>
+              </DropdownMenuItem>
+            );
+          })}
+        </div>
+
+        <DropdownMenuSeparator className="my-0" />
+        <DropdownMenuItem asChild className="rounded-none px-3 py-2.5 text-sm text-gray-600">
+          <Link href="/profile?tab=notifications" className="flex items-center gap-2 w-full">
+            <Settings className="h-4 w-4" />
+            Notification settings
+          </Link>
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
   );
 };
 

--- a/components/notifications/NotificationPreferences.tsx
+++ b/components/notifications/NotificationPreferences.tsx
@@ -310,7 +310,8 @@ const NotificationPreferences: React.FC = () => {
       </div>
 
       <p className="text-xs text-gray-400">
-        Push notifications require browser permission. Email preferences apply only to transactional messages—you will always receive critical account emails.
+        Push notifications require browser permission. Email preferences apply to most messages.
+        Critical booking, payment, dispute, and account alerts may still be sent even when a channel is turned off.
       </p>
     </div>
   );

--- a/contexts/FCMProvider.tsx
+++ b/contexts/FCMProvider.tsx
@@ -267,6 +267,7 @@ export const FCMProvider: React.FC<FCMProviderProps> = ({ isAuthenticated, child
       const url = data.clickUrl || '/';
 
       setUnreadPushCount((n) => n + 1);
+      window.dispatchEvent(new CustomEvent('fixtract:inbox-refresh'));
 
       toast(title, {
         description: body,

--- a/contexts/NotificationInboxProvider.tsx
+++ b/contexts/NotificationInboxProvider.tsx
@@ -1,0 +1,159 @@
+'use client';
+
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react';
+import { getAuthToken } from '@/lib/utils';
+
+export interface InboxNotification {
+  id: string;
+  eventKey: string;
+  category: string;
+  title: string;
+  body: string;
+  clickUrl: string;
+  entityType?: string;
+  entityId?: string;
+  readAt: string | null;
+  createdAt: string;
+}
+
+interface NotificationInboxContextValue {
+  items: InboxNotification[];
+  unreadCount: number;
+  loading: boolean;
+  refresh: () => Promise<void>;
+  markRead: (id: string) => Promise<void>;
+  markAllRead: () => Promise<void>;
+}
+
+const NotificationInboxContext = createContext<NotificationInboxContextValue>({
+  items: [],
+  unreadCount: 0,
+  loading: false,
+  refresh: async () => {},
+  markRead: async () => {},
+  markAllRead: async () => {},
+});
+
+export const useNotificationInbox = () => useContext(NotificationInboxContext);
+
+const BACKEND_URL = (process.env.NEXT_PUBLIC_BACKEND_URL ?? '').replace(/\/+$/, '');
+const POLL_MS = 45_000;
+
+function authHeaders(): Record<string, string> {
+  const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+  const token = getAuthToken();
+  if (token) headers.Authorization = `Bearer ${token}`;
+  return headers;
+}
+
+interface ProviderProps {
+  isAuthenticated: boolean;
+  children: React.ReactNode;
+}
+
+export const NotificationInboxProvider: React.FC<ProviderProps> = ({
+  isAuthenticated,
+  children,
+}) => {
+  const [items, setItems] = useState<InboxNotification[]>([]);
+  const [unreadCount, setUnreadCount] = useState(0);
+  const [loading, setLoading] = useState(false);
+
+  const refresh = useCallback(async () => {
+    if (!isAuthenticated || !BACKEND_URL) {
+      setItems([]);
+      setUnreadCount(0);
+      return;
+    }
+
+    setLoading(true);
+    try {
+      const res = await fetch(`${BACKEND_URL}/api/user/notifications?limit=20`, {
+        credentials: 'include',
+        headers: authHeaders(),
+      });
+      if (!res.ok) return;
+      const json = await res.json();
+      if (json?.success && json.data) {
+        setItems(json.data.items ?? []);
+        setUnreadCount(json.data.unreadCount ?? 0);
+      }
+    } catch {
+      // ignore transient network errors
+    } finally {
+      setLoading(false);
+    }
+  }, [isAuthenticated]);
+
+  const markRead = useCallback(async (id: string) => {
+    setItems((prev) =>
+      prev.map((n) => (n.id === id && !n.readAt ? { ...n, readAt: new Date().toISOString() } : n)),
+    );
+    setUnreadCount((c) => Math.max(0, c - 1));
+
+    try {
+      await fetch(`${BACKEND_URL}/api/user/notifications/${id}/read`, {
+        method: 'PATCH',
+        credentials: 'include',
+        headers: authHeaders(),
+      });
+    } catch {
+      void refresh();
+    }
+  }, [refresh]);
+
+  const markAllRead = useCallback(async () => {
+    setItems((prev) => prev.map((n) => ({ ...n, readAt: n.readAt || new Date().toISOString() })));
+    setUnreadCount(0);
+
+    try {
+      await fetch(`${BACKEND_URL}/api/user/notifications/read-all`, {
+        method: 'POST',
+        credentials: 'include',
+        headers: authHeaders(),
+      });
+    } catch {
+      void refresh();
+    }
+  }, [refresh]);
+
+  useEffect(() => {
+    if (!isAuthenticated) {
+      setItems([]);
+      setUnreadCount(0);
+      return;
+    }
+
+    void refresh();
+
+    const onFocus = () => { void refresh(); };
+    const onInboxRefresh = () => { void refresh(); };
+    window.addEventListener('focus', onFocus);
+    window.addEventListener('fixtract:inbox-refresh', onInboxRefresh);
+    const interval = window.setInterval(() => { void refresh(); }, POLL_MS);
+
+    return () => {
+      window.removeEventListener('focus', onFocus);
+      window.removeEventListener('fixtract:inbox-refresh', onInboxRefresh);
+      window.clearInterval(interval);
+    };
+  }, [isAuthenticated, refresh]);
+
+  const value = useMemo(
+    () => ({ items, unreadCount, loading, refresh, markRead, markAllRead }),
+    [items, unreadCount, loading, refresh, markRead, markAllRead],
+  );
+
+  return (
+    <NotificationInboxContext.Provider value={value}>
+      {children}
+    </NotificationInboxContext.Provider>
+  );
+};

--- a/contexts/NotificationInboxProvider.tsx
+++ b/contexts/NotificationInboxProvider.tsx
@@ -6,6 +6,7 @@ import React, {
   useContext,
   useEffect,
   useMemo,
+  useRef,
   useState,
 } from 'react';
 import { getAuthToken } from '@/lib/utils';
@@ -65,32 +66,48 @@ export const NotificationInboxProvider: React.FC<ProviderProps> = ({
   const [items, setItems] = useState<InboxNotification[]>([]);
   const [unreadCount, setUnreadCount] = useState(0);
   const [loading, setLoading] = useState(false);
+  const isAuthenticatedRef = useRef(isAuthenticated);
+  const abortRef = useRef<AbortController | null>(null);
+
+  useEffect(() => {
+    isAuthenticatedRef.current = isAuthenticated;
+  }, [isAuthenticated]);
 
   const refresh = useCallback(async () => {
-    if (!isAuthenticated || !BACKEND_URL) {
+    if (!isAuthenticatedRef.current || !BACKEND_URL) {
       setItems([]);
       setUnreadCount(0);
       return;
     }
+
+    abortRef.current?.abort();
+    const controller = new AbortController();
+    abortRef.current = controller;
 
     setLoading(true);
     try {
       const res = await fetch(`${BACKEND_URL}/api/user/notifications?limit=20`, {
         credentials: 'include',
         headers: authHeaders(),
+        signal: controller.signal,
       });
       if (!res.ok) return;
+      if (!isAuthenticatedRef.current || controller.signal.aborted) return;
       const json = await res.json();
+      if (!isAuthenticatedRef.current || controller.signal.aborted) return;
       if (json?.success && json.data) {
         setItems(json.data.items ?? []);
         setUnreadCount(json.data.unreadCount ?? 0);
       }
-    } catch {
+    } catch (err) {
+      if (err instanceof DOMException && err.name === 'AbortError') return;
       // ignore transient network errors
     } finally {
-      setLoading(false);
+      if (!controller.signal.aborted) {
+        setLoading(false);
+      }
     }
-  }, [isAuthenticated]);
+  }, []);
 
   const markRead = useCallback(async (id: string) => {
     setItems((prev) =>
@@ -99,11 +116,12 @@ export const NotificationInboxProvider: React.FC<ProviderProps> = ({
     setUnreadCount((c) => Math.max(0, c - 1));
 
     try {
-      await fetch(`${BACKEND_URL}/api/user/notifications/${id}/read`, {
+      const res = await fetch(`${BACKEND_URL}/api/user/notifications/${id}/read`, {
         method: 'PATCH',
         credentials: 'include',
         headers: authHeaders(),
       });
+      if (!res.ok) throw new Error('Failed to mark notification as read');
     } catch {
       void refresh();
     }
@@ -114,11 +132,12 @@ export const NotificationInboxProvider: React.FC<ProviderProps> = ({
     setUnreadCount(0);
 
     try {
-      await fetch(`${BACKEND_URL}/api/user/notifications/read-all`, {
+      const res = await fetch(`${BACKEND_URL}/api/user/notifications/read-all`, {
         method: 'POST',
         credentials: 'include',
         headers: authHeaders(),
       });
+      if (!res.ok) throw new Error('Failed to mark all notifications as read');
     } catch {
       void refresh();
     }
@@ -126,8 +145,11 @@ export const NotificationInboxProvider: React.FC<ProviderProps> = ({
 
   useEffect(() => {
     if (!isAuthenticated) {
+      abortRef.current?.abort();
+      abortRef.current = null;
       setItems([]);
       setUnreadCount(0);
+      setLoading(false);
       return;
     }
 
@@ -143,6 +165,7 @@ export const NotificationInboxProvider: React.FC<ProviderProps> = ({
       window.removeEventListener('focus', onFocus);
       window.removeEventListener('fixtract:inbox-refresh', onInboxRefresh);
       window.clearInterval(interval);
+      abortRef.current?.abort();
     };
   }, [isAuthenticated, refresh]);
 

--- a/contexts/NotificationInboxProvider.tsx
+++ b/contexts/NotificationInboxProvider.tsx
@@ -4,7 +4,7 @@ import React, {
   createContext,
   useCallback,
   useContext,
-  useEffect,
+  useLayoutEffect,
   useMemo,
   useRef,
   useState,
@@ -69,8 +69,16 @@ export const NotificationInboxProvider: React.FC<ProviderProps> = ({
   const isAuthenticatedRef = useRef(isAuthenticated);
   const abortRef = useRef<AbortController | null>(null);
 
-  useEffect(() => {
+  // Sync auth guard + clear inbox before paint so in-flight responses cannot repopulate after logout.
+  useLayoutEffect(() => {
     isAuthenticatedRef.current = isAuthenticated;
+    if (!isAuthenticated) {
+      abortRef.current?.abort();
+      abortRef.current = null;
+      setItems([]);
+      setUnreadCount(0);
+      setLoading(false);
+    }
   }, [isAuthenticated]);
 
   const refresh = useCallback(async () => {
@@ -144,14 +152,7 @@ export const NotificationInboxProvider: React.FC<ProviderProps> = ({
   }, [refresh]);
 
   useEffect(() => {
-    if (!isAuthenticated) {
-      abortRef.current?.abort();
-      abortRef.current = null;
-      setItems([]);
-      setUnreadCount(0);
-      setLoading(false);
-      return;
-    }
+    if (!isAuthenticated) return;
 
     void refresh();
 


### PR DESCRIPTION
## Summary
- Replace settings-only bell navigation with a notification inbox dropdown (unread badge, mark read / mark all read).
- Add `NotificationInboxProvider` to load and sync inbox data from the new user notifications API.
- Clarify always-on / email-always preference copy and expose admin actions for reminder + completion auto-accept jobs.

## Test plan
- [ ] Log in locally / on Vercel and open the bell — dropdown shows notifications (or empty state), does not jump to settings.
- [ ] Unread badge updates after mark-read / mark-all-read.
- [ ] Notification settings link in the dropdown still reaches preferences.
- [ ] Admin dashboard can trigger notification reminder and completion auto-accept runs (paired with server PR).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an in-app notification inbox from the notification bell, with a dropdown list, relative timestamps, and a notification settings link.
  - Users can mark individual notifications as read or mark all as read; selecting an item opens its destination.
  - Added admin controls to run notification reminders and completion auto-accept automated checks.
- **Improvements**
  - Inbox auto-refresh now reacts to new incoming notifications and continues periodic updates.
  - Expanded automated-check run feedback, including improved reminder/completion reporting.
  - Updated notification preferences wording to clarify that critical booking/payment/dispute/account alerts may still be sent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->