### PR TITLE
fix(notifications): import useEffect in inbox provider

### DIFF
--- a/contexts/NotificationInboxProvider.tsx
+++ b/contexts/NotificationInboxProvider.tsx
@@ -4,6 +4,7 @@ import React, {
   createContext,
   useCallback,
   useContext,
+  useEffect,
   useLayoutEffect,
   useMemo,
   useRef,


### PR DESCRIPTION
## Summary
- Fixes production `next build` failure: `Cannot find name 'useEffect'` in `NotificationInboxProvider.tsx`.
- Backend `tsc` build already passes; no server changes.

## Test plan
- [x] `npm run build` in `fixera/` succeeds
- [x] `npm run build` in `fixera-server/` succeeds

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved notification inbox updates and focus-based refresh behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->