### PR TITLE
feat(vat): RFQ chat and standard-rate path in booking wizard

### DIFF
--- a/components/notifications/NotificationBell.tsx
+++ b/components/notifications/NotificationBell.tsx
@@ -65,18 +65,27 @@ const NotificationBell: React.FC<NotificationBellProps> = ({ className = '' }) =
       </DropdownMenuTrigger>
 
       <DropdownMenuContent className="w-80 sm:w-96 p-0" align="end" forceMount>
-        <div className="flex items-center justify-between px-3 py-2.5">
+        <div className="flex items-center justify-between gap-2 px-3 py-2.5">
           <DropdownMenuLabel className="p-0 text-sm font-semibold">Notifications</DropdownMenuLabel>
-          {unreadCount > 0 && (
-            <button
-              type="button"
-              onClick={() => { void markAllRead(); }}
-              className="inline-flex items-center gap-1 text-xs text-blue-600 hover:text-blue-700 font-medium"
+          <div className="flex items-center gap-1">
+            {unreadCount > 0 && (
+              <button
+                type="button"
+                onClick={() => { void markAllRead(); }}
+                className="inline-flex items-center gap-1 text-xs text-blue-600 hover:text-blue-700 font-medium"
+              >
+                <CheckCheck className="h-3.5 w-3.5" />
+                Mark all read
+              </button>
+            )}
+            <Link
+              href="/profile?tab=notifications"
+              aria-label="Notification settings"
+              className="inline-flex h-7 w-7 items-center justify-center rounded-md text-gray-500 hover:text-gray-700 hover:bg-gray-100 transition-colors"
             >
-              <CheckCheck className="h-3.5 w-3.5" />
-              Mark all read
-            </button>
-          )}
+              <Settings className="h-4 w-4" />
+            </Link>
+          </div>
         </div>
         <DropdownMenuSeparator className="my-0" />
 
@@ -125,14 +134,6 @@ const NotificationBell: React.FC<NotificationBellProps> = ({ className = '' }) =
             );
           })}
         </div>
-
-        <DropdownMenuSeparator className="my-0" />
-        <DropdownMenuItem asChild className="rounded-none px-3 py-2.5 text-sm text-gray-600">
-          <Link href="/profile?tab=notifications" className="flex items-center gap-2 w-full">
-            <Settings className="h-4 w-4" />
-            Notification settings
-          </Link>
-        </DropdownMenuItem>
       </DropdownMenuContent>
     </DropdownMenu>
   );

--- a/components/notifications/NotificationBell.tsx
+++ b/components/notifications/NotificationBell.tsx
@@ -65,26 +65,30 @@ const NotificationBell: React.FC<NotificationBellProps> = ({ className = '' }) =
       </DropdownMenuTrigger>
 
       <DropdownMenuContent className="w-80 sm:w-96 p-0" align="end" forceMount>
-        <div className="flex items-center justify-between gap-2 px-3 py-2.5">
-          <DropdownMenuLabel className="p-0 text-sm font-semibold">Notifications</DropdownMenuLabel>
-          <div className="flex items-center gap-1">
+        <div className="flex items-center justify-between gap-2 px-1 py-1">
+          <DropdownMenuLabel className="px-2 py-1.5 text-sm font-semibold">Notifications</DropdownMenuLabel>
+          <div className="flex items-center">
             {unreadCount > 0 && (
-              <button
-                type="button"
-                onClick={() => { void markAllRead(); }}
-                className="inline-flex items-center gap-1 text-xs text-blue-600 hover:text-blue-700 font-medium"
+              <DropdownMenuItem
+                className="gap-1 px-2 py-1.5 text-xs font-medium text-blue-600 focus:text-blue-700 cursor-pointer rounded-sm"
+                onSelect={(e) => {
+                  e.preventDefault();
+                  void markAllRead();
+                }}
               >
                 <CheckCheck className="h-3.5 w-3.5" />
                 Mark all read
-              </button>
+              </DropdownMenuItem>
             )}
-            <Link
-              href="/profile?tab=notifications"
-              aria-label="Notification settings"
-              className="inline-flex h-7 w-7 items-center justify-center rounded-md text-gray-500 hover:text-gray-700 hover:bg-gray-100 transition-colors"
-            >
-              <Settings className="h-4 w-4" />
-            </Link>
+            <DropdownMenuItem asChild className="p-0">
+              <Link
+                href="/profile?tab=notifications"
+                aria-label="Notification settings"
+                className="inline-flex h-8 w-8 items-center justify-center rounded-md text-gray-500 hover:text-gray-700 hover:bg-gray-100 transition-colors"
+              >
+                <Settings className="h-4 w-4" />
+              </Link>
+            </DropdownMenuItem>
           </div>
         </div>
         <DropdownMenuSeparator className="my-0" />

--- a/components/project/ProjectBookingForm.tsx
+++ b/components/project/ProjectBookingForm.tsx
@@ -11,6 +11,7 @@ import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group';
 import { Checkbox } from '@/components/ui/checkbox';
 import { Badge } from '@/components/ui/badge';
 import AddressAutocomplete from '@/components/professional/project-wizard/AddressAutocomplete';
+import StartChatButton from '@/components/chat/StartChatButton';
 import {
   ArrowLeft,
   Calendar,
@@ -315,6 +316,7 @@ export default function ProjectBookingForm({
   const [rfqAnswers, setRFQAnswers] = useState<RFQAnswer[]>([]);
   const [vatAnswers, setVatAnswers] = useState<Record<string, VatAnswer>>({});
   const [vatPreview, setVatPreview] = useState<VatPreviewDecision | null>(null);
+  const [proceedAtStandardVat, setProceedAtStandardVat] = useState(false);
   const [uploadingQuestionIndexes, setUploadingQuestionIndexes] = useState<Set<number>>(new Set());
   const [selectedExtraOptions, setSelectedExtraOptions] = useState<number[]>(
     []
@@ -339,6 +341,7 @@ export default function ProjectBookingForm({
       return;
     }
     setVatPreview(null);
+    setProceedAtStandardVat(false);
     let cancelled = false;
     (async () => {
       try {
@@ -2209,14 +2212,23 @@ export default function ProjectBookingForm({
       const hasValidPackageAmount =
         typeof selectedPackage.pricing.amount === 'number' &&
         selectedPackage.pricing.amount >= 0;
+      const vatNeedsRfqReview =
+        vatPreview?.action === 'rfq' && !vatPreview?.reverseCharge && !proceedAtStandardVat;
       const shouldPayAtCheckout =
-        !isRfqPackage && hasValidPackageAmount && totalPrice > 0;
+        !isRfqPackage &&
+        hasValidPackageAmount &&
+        totalPrice > 0 &&
+        !vatNeedsRfqReview;
 
       const bookingData = {
         bookingType: 'project',
         projectId: project._id,
         serviceConfigurationId: project.serviceConfigurationId,
         vatAnswers: Object.values(vatAnswers),
+        proceedAtStandardVat:
+          proceedAtStandardVat &&
+          vatPreview?.action === 'rfq' &&
+          !vatPreview?.reverseCharge,
         preferredStartDate: isRfqPackage ? undefined : selectedDate,
         preferredStartTime:
           !isRfqPackage && projectMode === 'hours' && selectedTime
@@ -4412,10 +4424,52 @@ export default function ProjectBookingForm({
                       {finalDisplayTotal > 0 && vatPreview && !isRfqPackage && (
                         <div className='space-y-1 pt-2 border-t border-blue-200 text-sm'>
                           {vatPreview.action === 'rfq' && !vatPreview.reverseCharge ? (
-                            <p className='text-amber-700'>
-                              {vatPreview.explanation ||
-                                'Your answers require a VAT review. After submitting you can chat with the professional or proceed at the standard VAT rate.'}
-                            </p>
+                            <div className='space-y-3 rounded-md border border-amber-200 bg-amber-50 p-3'>
+                              <p className='text-amber-800'>
+                                {vatPreview.explanation ||
+                                  'Your answers require a VAT review or quotation.'}
+                              </p>
+                              {proceedAtStandardVat ? (
+                                <p className='text-xs text-green-700'>
+                                  You chose to proceed at the standard VAT rate (
+                                  {vatPreview.standardRate}%). Submit to continue checkout.
+                                </p>
+                              ) : (
+                                <p className='text-xs text-amber-700'>
+                                  Chat with the professional for a quotation, or proceed at the
+                                  standard VAT rate ({vatPreview.standardRate}%).
+                                </p>
+                              )}
+                              <div className='flex flex-wrap gap-2'>
+                                {project.professionalId?._id && (
+                                  <StartChatButton
+                                    professionalId={project.professionalId._id}
+                                    label='Chat for quotation'
+                                    size='sm'
+                                  />
+                                )}
+                                {!proceedAtStandardVat && (
+                                  <Button
+                                    type='button'
+                                    size='sm'
+                                    variant='outline'
+                                    onClick={() => setProceedAtStandardVat(true)}
+                                  >
+                                    Proceed at standard VAT rate
+                                  </Button>
+                                )}
+                                {proceedAtStandardVat && (
+                                  <Button
+                                    type='button'
+                                    size='sm'
+                                    variant='ghost'
+                                    onClick={() => setProceedAtStandardVat(false)}
+                                  >
+                                    Undo standard rate
+                                  </Button>
+                                )}
+                              </div>
+                            </div>
                           ) : vatPreview.reverseCharge ? (
                             <>
                               <div className='flex justify-between text-gray-700'>

--- a/components/project/ProjectBookingForm.tsx
+++ b/components/project/ProjectBookingForm.tsx
@@ -2212,8 +2212,6 @@ export default function ProjectBookingForm({
       const hasValidPackageAmount =
         typeof selectedPackage.pricing.amount === 'number' &&
         selectedPackage.pricing.amount >= 0;
-      const vatNeedsRfqReview =
-        vatPreview?.action === 'rfq' && !vatPreview?.reverseCharge && !proceedAtStandardVat;
       const shouldPayAtCheckout =
         !isRfqPackage &&
         hasValidPackageAmount &&
@@ -2560,12 +2558,15 @@ export default function ProjectBookingForm({
     repeatBuyerDiscountAmount > 0
       ? discountedDisplayTotalPrice ?? baseDisplayTotal
       : baseDisplayTotal;
+  const vatNeedsRfqReview =
+    vatPreview?.action === 'rfq' && !vatPreview?.reverseCharge && !proceedAtStandardVat;
   const shouldPayAtCheckoutFlow =
     Boolean(selectedPackage) &&
     selectedPackage?.pricing.type !== 'rfq' &&
     typeof selectedPackage?.pricing.amount === 'number' &&
     selectedPackage.pricing.amount >= 0 &&
-    finalDisplayTotal > 0;
+    finalDisplayTotal > 0 &&
+    !vatNeedsRfqReview;
   const finalStepLabel = shouldPayAtCheckoutFlow
     ? 'Review & Pay'
     : 'Review & Submit RFQ';


### PR DESCRIPTION
## Summary
- When VAT preview returns RFQ, the booking wizard shows chat-for-quotation and proceed-at-standard-VAT actions before submit.
- Checkout is blocked for RFQ until the customer opts into standard rate or completes post-booking flow.

## Test plan
- [x] `npm run build` in fixera passes
- [ ] Book a service with VAT RFQ logic on rho and confirm chat + standard-rate CTA appear on review step
- [ ] Confirm standard-rate path allows checkout at 21%

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an in-flow option to chat with the professional during VAT-preview RFQ quotation review.
  * Added controls to proceed at the standard VAT rate or continue quotation review, including an undo option.
* **UI Improvements**
  * Updated the VAT review step to show an interactive amber warning panel with the VAT-preview message and “Chat for quotation”.
  * Refreshed the notifications dropdown header to group the main actions and move settings into the top header.
* **Bug Fixes**
  * Corrected booking submission logic so checkout payment eligibility matches the selected VAT/RFQ quotation-review path.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->