### PR TITLE
Add admin RBAC UI and invite acceptance flow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,4 @@ next-env.d.ts
 nul
 package-lock.json
 /seo.md
+.demo-videos/

--- a/app/(pages)/admin/accept-invite/layout.tsx
+++ b/app/(pages)/admin/accept-invite/layout.tsx
@@ -1,0 +1,11 @@
+import type { Metadata } from 'next';
+import { noindexMetadata } from '@/lib/seo/metadata';
+
+export const metadata: Metadata = noindexMetadata(
+  '/admin/accept-invite',
+  'Accept admin invite'
+);
+
+export default function AdminAcceptInviteLayout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/app/(pages)/admin/accept-invite/page.tsx
+++ b/app/(pages)/admin/accept-invite/page.tsx
@@ -174,7 +174,7 @@ function AcceptInviteContent() {
                 onChange={(e) => setConfirmPassword(e.target.value)}
                 placeholder="Confirm your password"
                 required
-                minLength={6}
+                minLength={8}
               />
             </div>
 

--- a/app/(pages)/admin/accept-invite/page.tsx
+++ b/app/(pages)/admin/accept-invite/page.tsx
@@ -70,8 +70,8 @@ function AcceptInviteContent() {
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    if (password.length < 6) {
-      toast.error('Password must be at least 6 characters');
+    if (password.length < 8) {
+      toast.error('Password must be at least 8 characters');
       return;
     }
     if (password !== confirmPassword) {
@@ -151,11 +151,12 @@ function AcceptInviteContent() {
                   onChange={(e) => setPassword(e.target.value)}
                   placeholder="Choose a password"
                   required
-                  minLength={6}
+                  minLength={8}
                   className="pr-10"
                 />
                 <button
                   type="button"
+                  aria-label={showPassword ? 'Hide password' : 'Show password'}
                   onClick={() => setShowPassword(!showPassword)}
                   className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-500 hover:text-gray-700"
                 >

--- a/app/(pages)/admin/accept-invite/page.tsx
+++ b/app/(pages)/admin/accept-invite/page.tsx
@@ -36,6 +36,18 @@ function AcceptInviteContent() {
   const [submitting, setSubmitting] = useState(false);
 
   useEffect(() => {
+    setLoading(true);
+    setLoadError(null);
+    setDetails(null);
+    setPassword('');
+    setConfirmPassword('');
+
+    if (!API) {
+      setLoadError('App misconfigured: NEXT_PUBLIC_BACKEND_URL is missing.');
+      setLoading(false);
+      return;
+    }
+
     if (!token) {
       setLoadError('Missing invite token. Check the link from your email.');
       setLoading(false);
@@ -70,6 +82,10 @@ function AcceptInviteContent() {
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
+    if (!API) {
+      toast.error('App misconfigured: NEXT_PUBLIC_BACKEND_URL is missing.');
+      return;
+    }
     if (password.length < 8) {
       toast.error('Password must be at least 8 characters');
       return;
@@ -92,10 +108,16 @@ function AcceptInviteContent() {
         throw new Error(json.msg || 'Could not activate account');
       }
 
+      // Acceptance already succeeded — session sync failures must not look like activation failures
       setAuthToken(json.token);
-      await checkAuth();
-      toast.success('Account activated — welcome to the team');
-      router.push('/dashboard');
+      try {
+        await checkAuth();
+        toast.success('Account activated — welcome to the team');
+        router.push('/dashboard');
+      } catch {
+        toast.success('Account activated — please sign in to continue');
+        router.push('/login');
+      }
     } catch (err: unknown) {
       toast.error(err instanceof Error ? err.message : 'Could not activate account');
     } finally {

--- a/app/(pages)/admin/accept-invite/page.tsx
+++ b/app/(pages)/admin/accept-invite/page.tsx
@@ -1,0 +1,203 @@
+'use client';
+
+import { Suspense, useEffect, useState } from 'react';
+import Link from 'next/link';
+import { useRouter, useSearchParams } from 'next/navigation';
+import { toast } from 'sonner';
+import { Eye, EyeOff, Loader2 } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { useAuth } from '@/contexts/AuthContext';
+import { setAuthToken } from '@/lib/utils';
+
+const API = process.env.NEXT_PUBLIC_BACKEND_URL;
+
+type InviteDetails = {
+  name: string;
+  email: string;
+  adminRole: string;
+  roleLabel: string;
+};
+
+function AcceptInviteContent() {
+  const searchParams = useSearchParams();
+  const router = useRouter();
+  const { checkAuth } = useAuth();
+  const token = searchParams.get('token') || '';
+
+  const [details, setDetails] = useState<InviteDetails | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [password, setPassword] = useState('');
+  const [confirmPassword, setConfirmPassword] = useState('');
+  const [showPassword, setShowPassword] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+
+  useEffect(() => {
+    if (!token) {
+      setLoadError('Missing invite token. Check the link from your email.');
+      setLoading(false);
+      return;
+    }
+
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await fetch(
+          `${API}/api/auth/admin-invite?token=${encodeURIComponent(token)}`,
+          { credentials: 'include' }
+        );
+        const json = await res.json();
+        if (!res.ok || !json.success) {
+          throw new Error(json.msg || 'Invalid invite link');
+        }
+        if (!cancelled) setDetails(json.data);
+      } catch (err: unknown) {
+        if (!cancelled) {
+          setLoadError(err instanceof Error ? err.message : 'Invalid invite link');
+        }
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [token]);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (password.length < 6) {
+      toast.error('Password must be at least 6 characters');
+      return;
+    }
+    if (password !== confirmPassword) {
+      toast.error('Passwords do not match');
+      return;
+    }
+
+    setSubmitting(true);
+    try {
+      const res = await fetch(`${API}/api/auth/admin-invite/accept`, {
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ token, password }),
+      });
+      const json = await res.json();
+      if (!res.ok || !json.success) {
+        throw new Error(json.msg || 'Could not activate account');
+      }
+
+      setAuthToken(json.token);
+      await checkAuth();
+      toast.success('Account activated — welcome to the team');
+      router.push('/dashboard');
+    } catch (err: unknown) {
+      toast.error(err instanceof Error ? err.message : 'Could not activate account');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-slate-50 p-4">
+        <Loader2 className="h-8 w-8 animate-spin text-slate-400" />
+      </div>
+    );
+  }
+
+  if (loadError || !details) {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-slate-50 p-4">
+        <Card className="w-full max-w-md">
+          <CardHeader>
+            <CardTitle>Invite link unavailable</CardTitle>
+            <CardDescription>{loadError || 'This invite link is invalid or has expired.'}</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <Link href="/login" className="text-sm text-blue-600 hover:underline">
+              Go to sign in
+            </Link>
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-gradient-to-br from-blue-50 to-indigo-100 p-4">
+      <Card className="w-full max-w-md">
+        <CardHeader className="space-y-1">
+          <CardTitle className="text-center text-2xl font-bold">Set up your admin account</CardTitle>
+          <CardDescription className="text-center">
+            Hi {details.name}, you&apos;ve been invited as <strong>{details.roleLabel}</strong> (
+            {details.email}).
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <div className="space-y-2">
+              <Label htmlFor="password">Password</Label>
+              <div className="relative">
+                <Input
+                  id="password"
+                  type={showPassword ? 'text' : 'password'}
+                  value={password}
+                  onChange={(e) => setPassword(e.target.value)}
+                  placeholder="Choose a password"
+                  required
+                  minLength={6}
+                  className="pr-10"
+                />
+                <button
+                  type="button"
+                  onClick={() => setShowPassword(!showPassword)}
+                  className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-500 hover:text-gray-700"
+                >
+                  {showPassword ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+                </button>
+              </div>
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="confirm-password">Confirm password</Label>
+              <Input
+                id="confirm-password"
+                type={showPassword ? 'text' : 'password'}
+                value={confirmPassword}
+                onChange={(e) => setConfirmPassword(e.target.value)}
+                placeholder="Confirm your password"
+                required
+                minLength={6}
+              />
+            </div>
+
+            <Button type="submit" className="w-full bg-blue-600 hover:bg-blue-700" disabled={submitting}>
+              {submitting ? (
+                <>
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                  Activating…
+                </>
+              ) : (
+                'Activate account'
+              )}
+            </Button>
+          </form>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
+export default function AdminAcceptInvitePage() {
+  return (
+    <Suspense fallback={<div className="min-h-screen bg-slate-50" />}>
+      <AcceptInviteContent />
+    </Suspense>
+  );
+}

--- a/app/(pages)/admin/layout.tsx
+++ b/app/(pages)/admin/layout.tsx
@@ -1,8 +1,9 @@
 import type { Metadata } from "next";
 import { noindexMetadata } from "@/lib/seo/metadata";
+import AdminAccessGate from "@/components/admin/AdminAccessGate";
 
 export const metadata: Metadata = noindexMetadata("/admin", "Admin");
 
 export default function AdminLayout({ children }: { children: React.ReactNode }) {
-  return children;
+  return <AdminAccessGate>{children}</AdminAccessGate>;
 }

--- a/app/(pages)/admin/staff/page.tsx
+++ b/app/(pages)/admin/staff/page.tsx
@@ -481,17 +481,25 @@ function StaffPageInner() {
                               variant={
                                 member.accountStatus === 'active'
                                   ? 'secondary'
-                                  : member.accountStatus === 'pending'
+                                  : member.accountStatus === 'pending' ||
+                                      member.accountStatus === 'invite_expired'
                                     ? 'outline'
                                     : 'destructive'
                               }
                               className="font-normal capitalize"
                             >
-                              {member.accountStatus}
+                              {member.accountStatus === 'invite_expired'
+                                ? 'Invite expired'
+                                : member.accountStatus}
                             </Badge>
                           </td>
                           <td className="px-3 py-3 text-right">
-                            {member.invitePending || member.accountStatus === 'pending' ? (
+                            {member.accountStatus !== 'suspended' &&
+                            member.accountStatus !== 'rejected' &&
+                            (member.invitePending ||
+                              member.inviteExpired ||
+                              member.accountStatus === 'pending' ||
+                              member.accountStatus === 'invite_expired') ? (
                               <Button
                                 variant="outline"
                                 size="sm"

--- a/app/(pages)/admin/staff/page.tsx
+++ b/app/(pages)/admin/staff/page.tsx
@@ -19,6 +19,7 @@ import {
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { ArrowLeft, Check, Copy, Loader2 } from 'lucide-react';
+import { messageFromApiBody, readJsonResponse } from '@/lib/apiErrors';
 
 type StaffMember = {
   _id: string;
@@ -27,6 +28,7 @@ type StaffMember = {
   phone?: string;
   adminRole: AdminRole;
   accountStatus: string;
+  invitePending?: boolean;
   permissions: string[];
   createdAt?: string;
 };
@@ -87,8 +89,10 @@ function StaffPageInner() {
     if (!silent) setLoading(true);
     try {
       const res = await fetch(`${API}/api/admin/staff`, authInit());
-      const json = await res.json();
-      if (!res.ok || !json.success) throw new Error(json.msg || 'Failed to load staff');
+      const json = await readJsonResponse<{ data?: StaffMember[] }>(res);
+      if (!res.ok || !json.success) {
+        throw new Error(messageFromApiBody(json, 'Failed to load staff'));
+      }
       setStaff(json.data || []);
     } catch (err: unknown) {
       if (!silent) toast.error(err instanceof Error ? err.message : 'Failed to load staff');
@@ -102,6 +106,31 @@ function StaffPageInner() {
     void load();
   }, [load]);
 
+  const applyInviteResponse = (
+    json: {
+      data?: StaffMember;
+      inviteUrl?: string;
+      emailSent?: boolean;
+      emailError?: string;
+      resent?: boolean;
+      msg?: string;
+    }
+  ) => {
+    setLastInviteUrl(json.inviteUrl || null);
+    if (json.emailSent) {
+      toast.success(
+        json.resent
+          ? `Invite resent to ${json.data?.email}`
+          : `Invite email sent to ${json.data?.email}`
+      );
+    } else {
+      toast.warning(json.msg || `Invite ready for ${json.data?.email} — email was not sent`);
+      if (json.emailError) {
+        toast.message(json.emailError, { duration: 8000 });
+      }
+    }
+  };
+
   const invite = async (e: React.FormEvent) => {
     e.preventDefault();
     setSubmitting(true);
@@ -114,23 +143,29 @@ function StaffPageInner() {
           body: JSON.stringify({ name, email, phone: phone || undefined, adminRole }),
         })
       );
-      const json = await res.json();
-      if (!res.ok || !json.success) throw new Error(json.msg || 'Invite failed');
-      setLastInviteUrl(json.inviteUrl || null);
-      if (json.emailSent) {
-        toast.success(`Invite email sent to ${json.data?.email}`);
-      } else {
-        toast.success(`Invited ${json.data?.email}`);
-        toast.message('Email not sent — copy the invite link below');
+      const json = await readJsonResponse<{
+        success?: boolean;
+        msg?: string;
+        field?: 'email' | 'phone' | 'name';
+        inviteUrl?: string;
+        emailSent?: boolean;
+        emailError?: string;
+        resent?: boolean;
+        data?: StaffMember;
+      }>(res);
+      if (!res.ok || !json.success) {
+        throw new Error(messageFromApiBody(json, `Invite failed (${res.status})`));
       }
+      applyInviteResponse(json);
       setName('');
       setEmail('');
       setPhone('');
       setAdminRole('care');
       if (json.data) {
+        const member = json.data;
         setStaff((prev) => {
-          const exists = prev.some((m) => m._id === json.data._id);
-          return exists ? prev.map((m) => (m._id === json.data._id ? json.data : m)) : [json.data, ...prev];
+          const exists = prev.some((m) => m._id === member._id);
+          return exists ? prev.map((m) => (m._id === member._id ? member : m)) : [member, ...prev];
         });
       } else {
         await load({ silent: true });
@@ -156,10 +191,13 @@ function StaffPageInner() {
         `${API}/api/admin/staff/${staffId}`,
         authInit({ method: 'PATCH', body: JSON.stringify({ adminRole: nextRole }) })
       );
-      const json = await res.json();
-      if (!res.ok || !json.success) throw new Error(json.msg || 'Update failed');
+      const json = await readJsonResponse<{ data?: StaffMember }>(res);
+      if (!res.ok || !json.success) {
+        throw new Error(messageFromApiBody(json, 'Update failed'));
+      }
       if (json.data) {
-        setStaff((prev) => prev.map((m) => (m._id === staffId ? { ...m, ...json.data } : m)));
+        const updated = json.data;
+        setStaff((prev) => prev.map((m) => (m._id === staffId ? { ...m, ...updated } : m)));
       }
       toast.success('Role updated');
     } catch (err: unknown) {
@@ -167,6 +205,35 @@ function StaffPageInner() {
       toast.error(err instanceof Error ? err.message : 'Update failed');
     } finally {
       setRowBusy(staffId, false);
+    }
+  };
+
+  const resendInvite = async (member: StaffMember) => {
+    setRowBusy(member._id, true);
+    try {
+      const res = await fetch(
+        `${API}/api/admin/staff/${member._id}/resend-invite`,
+        authInit({ method: 'POST' })
+      );
+      const json = await readJsonResponse<{
+        data?: StaffMember;
+        inviteUrl?: string;
+        emailSent?: boolean;
+        emailError?: string;
+        resent?: boolean;
+        msg?: string;
+      }>(res);
+      if (!res.ok || !json.success) {
+        throw new Error(messageFromApiBody(json, 'Resend failed'));
+      }
+      applyInviteResponse(json);
+      if (json.data) {
+        setStaff((prev) => prev.map((m) => (m._id === member._id ? { ...m, ...json.data } : m)));
+      }
+    } catch (err: unknown) {
+      toast.error(err instanceof Error ? err.message : 'Resend failed');
+    } finally {
+      setRowBusy(member._id, false);
     }
   };
 
@@ -184,8 +251,17 @@ function StaffPageInner() {
         `${API}/api/admin/staff/${member._id}`,
         authInit({ method: 'PATCH', body: JSON.stringify({ accountStatus: next }) })
       );
-      const json = await res.json();
-      if (!res.ok || !json.success) throw new Error(json.msg || 'Update failed');
+      const json = await readJsonResponse<{
+        data?: StaffMember;
+        inviteUrl?: string;
+        emailSent?: boolean;
+        emailError?: string;
+        resent?: boolean;
+        msg?: string;
+      }>(res);
+      if (!res.ok || !json.success) {
+        throw new Error(messageFromApiBody(json, 'Update failed'));
+      }
       if (json.data) {
         setStaff((prev) =>
           prev.map((m) => (m._id === member._id ? { ...m, ...json.data } : m))
@@ -424,14 +500,25 @@ function StaffPageInner() {
                             </Badge>
                           </td>
                           <td className="px-3 py-3 text-right">
-                            <Button
-                              variant="outline"
-                              size="sm"
-                              onClick={() => toggleStatus(member)}
-                              disabled={isSelf || rowBusy}
-                            >
-                              {member.accountStatus === 'active' ? 'Suspend' : 'Reactivate'}
-                            </Button>
+                            {member.invitePending || member.accountStatus === 'pending' ? (
+                              <Button
+                                variant="outline"
+                                size="sm"
+                                onClick={() => resendInvite(member)}
+                                disabled={isSelf || rowBusy}
+                              >
+                                Resend invite
+                              </Button>
+                            ) : (
+                              <Button
+                                variant="outline"
+                                size="sm"
+                                onClick={() => toggleStatus(member)}
+                                disabled={isSelf || rowBusy}
+                              >
+                                {member.accountStatus === 'active' ? 'Suspend' : 'Reactivate'}
+                              </Button>
+                            )}
                           </td>
                         </tr>
                       );

--- a/app/(pages)/admin/staff/page.tsx
+++ b/app/(pages)/admin/staff/page.tsx
@@ -5,7 +5,13 @@ import Link from 'next/link';
 import { toast } from 'sonner';
 import { useAuth } from '@/contexts/AuthContext';
 import { RequireAdminPermission } from '@/components/admin/RequireAdminPermission';
-import { ADMIN_ROLE_ACCESS, ADMIN_ROLE_LABELS, ADMIN_ROLES, type AdminRole } from '@/lib/adminRbac';
+import {
+  ADMIN_ACCESS_MATRIX,
+  ADMIN_ROLE_ACCESS,
+  ADMIN_ROLE_LABELS,
+  ADMIN_ROLES,
+  type AdminRole,
+} from '@/lib/adminRbac';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
@@ -29,28 +35,12 @@ type StaffMember = {
   adminRole: AdminRole;
   accountStatus: string;
   invitePending?: boolean;
+  inviteExpired?: boolean;
   permissions: string[];
   createdAt?: string;
 };
 
 const API = process.env.NEXT_PUBLIC_BACKEND_URL;
-
-/** Rows for the area × role matrix (product-facing labels). */
-const ACCESS_MATRIX: Array<{ area: string; roles: AdminRole[] }> = [
-  { area: 'Staff & roles', roles: ['super'] },
-  { area: 'Platform settings', roles: ['super'] },
-  { area: 'Bookings', roles: ['super', 'care', 'finance'] },
-  { area: 'Disputes & cancellations', roles: ['super', 'care'] },
-  { area: 'Support chat / tickets', roles: ['super', 'care'] },
-  { area: 'Customers', roles: ['super', 'care'] },
-  { area: 'Warranty claims', roles: ['super', 'care', 'quality'] },
-  { area: 'CMS & discount codes', roles: ['super', 'marketing'] },
-  { area: 'Loyalty / referrals / backlinks', roles: ['super', 'marketing'] },
-  { area: 'Professional & project approvals', roles: ['super', 'quality'] },
-  { area: 'Reviews & services', roles: ['super', 'quality'] },
-  { area: 'Payments', roles: ['super', 'finance'] },
-  { area: 'KPI / audit / email logs', roles: ['super', 'finance'] },
-];
 
 function authInit(init?: RequestInit): RequestInit {
   return {
@@ -116,7 +106,8 @@ function StaffPageInner() {
       msg?: string;
     }
   ) => {
-    setLastInviteUrl(json.inviteUrl || null);
+    // Only surface the bearer invite URL when email delivery failed
+    setLastInviteUrl(json.emailSent ? null : json.inviteUrl || null);
     if (json.emailSent) {
       toast.success(
         json.resent
@@ -550,7 +541,7 @@ function StaffPageInner() {
                 </tr>
               </thead>
               <tbody className="divide-y">
-                {ACCESS_MATRIX.map((row) => (
+                {ADMIN_ACCESS_MATRIX.map((row) => (
                   <tr key={row.area} className="hover:bg-slate-50/80">
                     <td className="px-4 py-2.5 text-slate-800">{row.area}</td>
                     {ADMIN_ROLES.map((role) => (

--- a/app/(pages)/admin/staff/page.tsx
+++ b/app/(pages)/admin/staff/page.tsx
@@ -1,0 +1,497 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import Link from 'next/link';
+import { toast } from 'sonner';
+import { useAuth } from '@/contexts/AuthContext';
+import { RequireAdminPermission } from '@/components/admin/RequireAdminPermission';
+import { ADMIN_ROLE_ACCESS, ADMIN_ROLE_LABELS, ADMIN_ROLES, type AdminRole } from '@/lib/adminRbac';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { ArrowLeft, Check, Copy, Loader2 } from 'lucide-react';
+
+type StaffMember = {
+  _id: string;
+  name: string;
+  email: string;
+  phone?: string;
+  adminRole: AdminRole;
+  accountStatus: string;
+  permissions: string[];
+  createdAt?: string;
+};
+
+const API = process.env.NEXT_PUBLIC_BACKEND_URL;
+
+/** Rows for the area × role matrix (product-facing labels). */
+const ACCESS_MATRIX: Array<{ area: string; roles: AdminRole[] }> = [
+  { area: 'Staff & roles', roles: ['super'] },
+  { area: 'Platform settings', roles: ['super'] },
+  { area: 'Bookings', roles: ['super', 'care', 'finance'] },
+  { area: 'Disputes & cancellations', roles: ['super', 'care'] },
+  { area: 'Support chat / tickets', roles: ['super', 'care'] },
+  { area: 'Customers', roles: ['super', 'care'] },
+  { area: 'Warranty claims', roles: ['super', 'care', 'quality'] },
+  { area: 'CMS & discount codes', roles: ['super', 'marketing'] },
+  { area: 'Loyalty / referrals / backlinks', roles: ['super', 'marketing'] },
+  { area: 'Professional & project approvals', roles: ['super', 'quality'] },
+  { area: 'Reviews & services', roles: ['super', 'quality'] },
+  { area: 'Payments', roles: ['super', 'finance'] },
+  { area: 'KPI / audit / email logs', roles: ['super', 'finance'] },
+];
+
+function authInit(init?: RequestInit): RequestInit {
+  return {
+    credentials: 'include',
+    ...init,
+    headers: {
+      'Content-Type': 'application/json',
+      ...(init?.headers || {}),
+    },
+  };
+}
+
+function StaffPageInner() {
+  const { user } = useAuth();
+  const [staff, setStaff] = useState<StaffMember[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [busyIds, setBusyIds] = useState<Set<string>>(new Set());
+  const [name, setName] = useState('');
+  const [email, setEmail] = useState('');
+  const [phone, setPhone] = useState('');
+  const [adminRole, setAdminRole] = useState<AdminRole>('care');
+  const [submitting, setSubmitting] = useState(false);
+  const [lastInviteUrl, setLastInviteUrl] = useState<string | null>(null);
+
+  const setRowBusy = (id: string, busy: boolean) => {
+    setBusyIds((prev) => {
+      const next = new Set(prev);
+      if (busy) next.add(id);
+      else next.delete(id);
+      return next;
+    });
+  };
+
+  const load = useCallback(async (opts?: { silent?: boolean }) => {
+    const silent = opts?.silent === true;
+    if (!silent) setLoading(true);
+    try {
+      const res = await fetch(`${API}/api/admin/staff`, authInit());
+      const json = await res.json();
+      if (!res.ok || !json.success) throw new Error(json.msg || 'Failed to load staff');
+      setStaff(json.data || []);
+    } catch (err: unknown) {
+      if (!silent) toast.error(err instanceof Error ? err.message : 'Failed to load staff');
+      throw err;
+    } finally {
+      if (!silent) setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const invite = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setSubmitting(true);
+    setLastInviteUrl(null);
+    try {
+      const res = await fetch(
+        `${API}/api/admin/staff`,
+        authInit({
+          method: 'POST',
+          body: JSON.stringify({ name, email, phone: phone || undefined, adminRole }),
+        })
+      );
+      const json = await res.json();
+      if (!res.ok || !json.success) throw new Error(json.msg || 'Invite failed');
+      setLastInviteUrl(json.inviteUrl || null);
+      if (json.emailSent) {
+        toast.success(`Invite email sent to ${json.data?.email}`);
+      } else {
+        toast.success(`Invited ${json.data?.email}`);
+        toast.message('Email not sent — copy the invite link below');
+      }
+      setName('');
+      setEmail('');
+      setPhone('');
+      setAdminRole('care');
+      if (json.data) {
+        setStaff((prev) => {
+          const exists = prev.some((m) => m._id === json.data._id);
+          return exists ? prev.map((m) => (m._id === json.data._id ? json.data : m)) : [json.data, ...prev];
+        });
+      } else {
+        await load({ silent: true });
+      }
+    } catch (err: unknown) {
+      toast.error(err instanceof Error ? err.message : 'Invite failed');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const updateRole = async (staffId: string, nextRole: AdminRole) => {
+    const previous = staff.find((m) => m._id === staffId);
+    if (!previous || previous.adminRole === nextRole) return;
+
+    setRowBusy(staffId, true);
+    setStaff((prev) =>
+      prev.map((m) => (m._id === staffId ? { ...m, adminRole: nextRole } : m))
+    );
+
+    try {
+      const res = await fetch(
+        `${API}/api/admin/staff/${staffId}`,
+        authInit({ method: 'PATCH', body: JSON.stringify({ adminRole: nextRole }) })
+      );
+      const json = await res.json();
+      if (!res.ok || !json.success) throw new Error(json.msg || 'Update failed');
+      if (json.data) {
+        setStaff((prev) => prev.map((m) => (m._id === staffId ? { ...m, ...json.data } : m)));
+      }
+      toast.success('Role updated');
+    } catch (err: unknown) {
+      setStaff((prev) => prev.map((m) => (m._id === staffId ? previous : m)));
+      toast.error(err instanceof Error ? err.message : 'Update failed');
+    } finally {
+      setRowBusy(staffId, false);
+    }
+  };
+
+  const toggleStatus = async (member: StaffMember) => {
+    const next = member.accountStatus === 'active' ? 'suspended' : 'active';
+    const previousStatus = member.accountStatus;
+
+    setRowBusy(member._id, true);
+    setStaff((prev) =>
+      prev.map((m) => (m._id === member._id ? { ...m, accountStatus: next } : m))
+    );
+
+    try {
+      const res = await fetch(
+        `${API}/api/admin/staff/${member._id}`,
+        authInit({ method: 'PATCH', body: JSON.stringify({ accountStatus: next }) })
+      );
+      const json = await res.json();
+      if (!res.ok || !json.success) throw new Error(json.msg || 'Update failed');
+      if (json.data) {
+        setStaff((prev) =>
+          prev.map((m) => (m._id === member._id ? { ...m, ...json.data } : m))
+        );
+      }
+      toast.success(next === 'active' ? 'Staff reactivated' : 'Staff suspended');
+    } catch (err: unknown) {
+      setStaff((prev) =>
+        prev.map((m) =>
+          m._id === member._id ? { ...m, accountStatus: previousStatus } : m
+        )
+      );
+      toast.error(err instanceof Error ? err.message : 'Update failed');
+    } finally {
+      setRowBusy(member._id, false);
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-slate-50 p-4 pt-24 pb-12">
+      <div className="mx-auto max-w-5xl space-y-6">
+        <div>
+          <Link
+            href="/dashboard"
+            className="mb-3 inline-flex items-center gap-1 text-sm text-slate-500 hover:text-slate-800"
+          >
+            <ArrowLeft className="h-4 w-4" />
+            Dashboard
+          </Link>
+          <h1 className="text-2xl font-semibold text-slate-900">Staff & roles</h1>
+          <p className="mt-1 text-sm text-slate-600">
+            Invite team members and assign care, marketing, quality, or finance access. Signed in as{' '}
+            {user?.name}.
+          </p>
+        </div>
+
+        <Card>
+          <CardHeader className="border-b pb-4">
+            <CardTitle className="text-lg">Invite staff</CardTitle>
+            <CardDescription>
+              Fill in their details, pick a role, then send the invite. They&apos;ll get an email with a
+              link to set their password.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="pt-6">
+            <form onSubmit={invite} className="grid gap-8 lg:grid-cols-2">
+              <div className="space-y-4">
+                <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+                  Contact details
+                </p>
+                <div className="space-y-2">
+                  <Label htmlFor="staff-name">Name</Label>
+                  <Input
+                    id="staff-name"
+                    value={name}
+                    onChange={(e) => setName(e.target.value)}
+                    placeholder="Alex Johnson"
+                    required
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="staff-email">Email</Label>
+                  <Input
+                    id="staff-email"
+                    type="email"
+                    value={email}
+                    onChange={(e) => setEmail(e.target.value)}
+                    placeholder="alex@fixtract.com"
+                    required
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="staff-phone">Phone (optional)</Label>
+                  <Input
+                    id="staff-phone"
+                    value={phone}
+                    onChange={(e) => setPhone(e.target.value)}
+                    placeholder="+32 …"
+                  />
+                </div>
+                <div className="flex flex-wrap items-center gap-2">
+                  <Button type="submit" disabled={submitting}>
+                    {submitting ? (
+                      <>
+                        <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                        Inviting…
+                      </>
+                    ) : (
+                      'Invite admin'
+                    )}
+                  </Button>
+                  {lastInviteUrl ? (
+                    <div className="inline-flex h-9 max-w-full items-center gap-2 rounded-md border border-blue-200 bg-blue-50 px-2.5 text-sm text-blue-950">
+                      <span className="truncate">Invite link ready</span>
+                      <button
+                        type="button"
+                        onClick={async () => {
+                          try {
+                            await navigator.clipboard.writeText(lastInviteUrl);
+                            toast.success('Invite link copied');
+                          } catch {
+                            toast.error('Could not copy');
+                          }
+                        }}
+                        className="inline-flex h-7 w-7 shrink-0 items-center justify-center rounded text-blue-900 hover:bg-blue-100"
+                        aria-label="Copy invite link"
+                      >
+                        <Copy className="h-3.5 w-3.5" />
+                      </button>
+                    </div>
+                  ) : null}
+                </div>
+              </div>
+
+              <div className="space-y-4">
+                <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+                  Role & access
+                </p>
+                <div className="space-y-2" role="radiogroup" aria-label="Admin role">
+                  {ADMIN_ROLES.map((role) => {
+                    const selected = adminRole === role;
+                    return (
+                      <button
+                        key={role}
+                        type="button"
+                        role="radio"
+                        aria-checked={selected}
+                        onClick={() => setAdminRole(role)}
+                        className={
+                          selected
+                            ? 'flex w-full items-start gap-3 rounded-lg border border-slate-900 bg-slate-900 px-3 py-2.5 text-left text-white'
+                            : 'flex w-full items-start gap-3 rounded-lg border border-slate-200 bg-white px-3 py-2.5 text-left text-slate-900 hover:border-slate-300 hover:bg-slate-50'
+                        }
+                      >
+                        <span
+                          className={
+                            selected
+                              ? 'mt-0.5 flex h-4 w-4 shrink-0 items-center justify-center rounded-full border-2 border-white'
+                              : 'mt-0.5 flex h-4 w-4 shrink-0 rounded-full border-2 border-slate-300'
+                          }
+                          aria-hidden
+                        >
+                          {selected ? <span className="h-1.5 w-1.5 rounded-full bg-white" /> : null}
+                        </span>
+                        <span className="min-w-0">
+                          <span className="block text-sm font-medium">{ADMIN_ROLE_LABELS[role]}</span>
+                          <span
+                            className={
+                              selected
+                                ? 'mt-0.5 block text-xs text-slate-300'
+                                : 'mt-0.5 block text-xs text-slate-500'
+                            }
+                          >
+                            {ADMIN_ROLE_ACCESS[role].slice(0, 3).join(' · ')}
+                            {ADMIN_ROLE_ACCESS[role].length > 3
+                              ? ` · +${ADMIN_ROLE_ACCESS[role].length - 3} more`
+                              : ''}
+                          </span>
+                        </span>
+                      </button>
+                    );
+                  })}
+                </div>
+              </div>
+            </form>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-lg">Team</CardTitle>
+            <CardDescription>
+              {loading ? 'Loading…' : `${staff.length} admin account${staff.length === 1 ? '' : 's'}`}
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            {loading ? (
+              <p className="text-sm text-slate-500">Loading staff…</p>
+            ) : staff.length === 0 ? (
+              <p className="text-sm text-slate-500">No staff accounts yet.</p>
+            ) : (
+              <div className="overflow-x-auto rounded-md border">
+                <table className="w-full min-w-[640px] text-left text-sm">
+                  <thead className="border-b bg-slate-50 text-xs uppercase tracking-wide text-slate-500">
+                    <tr>
+                      <th className="px-3 py-2.5 font-medium">Name</th>
+                      <th className="px-3 py-2.5 font-medium">Email</th>
+                      <th className="px-3 py-2.5 font-medium">Role</th>
+                      <th className="px-3 py-2.5 text-center font-medium">Status</th>
+                      <th className="px-3 py-2.5 font-medium text-right">Actions</th>
+                    </tr>
+                  </thead>
+                  <tbody className="divide-y bg-white">
+                    {staff.map((member) => {
+                      const isSelf = member._id === user?._id;
+                      const rowBusy = busyIds.has(member._id);
+                      return (
+                        <tr key={member._id} className="hover:bg-slate-50/80">
+                          <td className="px-3 py-3 font-medium text-slate-900">
+                            {member.name}
+                            {isSelf ? (
+                              <span className="ml-2 text-xs font-normal text-slate-400">you</span>
+                            ) : null}
+                          </td>
+                          <td className="px-3 py-3 text-slate-600">{member.email}</td>
+                          <td className="px-3 py-3">
+                            <Select
+                              value={member.adminRole}
+                              onValueChange={(v) => updateRole(member._id, v as AdminRole)}
+                              disabled={isSelf || rowBusy}
+                            >
+                              <SelectTrigger className="h-8 w-[150px]">
+                                <SelectValue />
+                              </SelectTrigger>
+                              <SelectContent>
+                                {ADMIN_ROLES.map((role) => (
+                                  <SelectItem key={role} value={role}>
+                                    {ADMIN_ROLE_LABELS[role]}
+                                  </SelectItem>
+                                ))}
+                              </SelectContent>
+                            </Select>
+                          </td>
+                          <td className="px-3 py-3 text-center">
+                            <Badge
+                              variant={
+                                member.accountStatus === 'active'
+                                  ? 'secondary'
+                                  : member.accountStatus === 'pending'
+                                    ? 'outline'
+                                    : 'destructive'
+                              }
+                              className="font-normal capitalize"
+                            >
+                              {member.accountStatus}
+                            </Badge>
+                          </td>
+                          <td className="px-3 py-3 text-right">
+                            <Button
+                              variant="outline"
+                              size="sm"
+                              onClick={() => toggleStatus(member)}
+                              disabled={isSelf || rowBusy}
+                            >
+                              {member.accountStatus === 'active' ? 'Suspend' : 'Reactivate'}
+                            </Button>
+                          </td>
+                        </tr>
+                      );
+                    })}
+                  </tbody>
+                </table>
+              </div>
+            )}
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-lg">Role access overview</CardTitle>
+            <CardDescription>
+              Quick reference for what each role can open in admin.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="overflow-x-auto p-0">
+            <table className="w-full min-w-[640px] text-left text-sm">
+              <thead className="border-y bg-slate-50 text-xs uppercase tracking-wide text-slate-500">
+                <tr>
+                  <th className="px-4 py-2.5 font-medium">Admin area</th>
+                  {ADMIN_ROLES.map((role) => (
+                    <th key={role} className="px-3 py-2.5 text-center font-medium">
+                      {ADMIN_ROLE_LABELS[role]}
+                    </th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody className="divide-y">
+                {ACCESS_MATRIX.map((row) => (
+                  <tr key={row.area} className="hover:bg-slate-50/80">
+                    <td className="px-4 py-2.5 text-slate-800">{row.area}</td>
+                    {ADMIN_ROLES.map((role) => (
+                      <td key={role} className="px-3 py-2.5 text-center">
+                        {row.roles.includes(role) ? (
+                          <Check className="mx-auto h-4 w-4 text-emerald-600" aria-label="Yes" />
+                        ) : (
+                          <span className="text-slate-300" aria-label="No">
+                            —
+                          </span>
+                        )}
+                      </td>
+                    ))}
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+}
+
+export default function AdminStaffPage() {
+  return (
+    <RequireAdminPermission permission="staff.manage">
+      <StaffPageInner />
+    </RequireAdminPermission>
+  );
+}

--- a/app/(pages)/dashboard/page.tsx
+++ b/app/(pages)/dashboard/page.tsx
@@ -16,6 +16,8 @@ import { type BookingStatus, getBookingStatusMeta, getBookingTitle, isProjectBoo
 import { getProfessionalActionItems } from "@/lib/actionNeededHelpers"
 import { Skeleton } from "@/components/ui/skeleton"
 import { toast } from "sonner"
+import { useAdminAccess } from "@/hooks/useAdminAccess"
+import { ADMIN_ROLE_LABELS, type AdminRole } from "@/lib/adminRbac"
 
 interface LoyaltyStats {
   tierDistribution: Array<{
@@ -126,6 +128,15 @@ interface WarrantyDashboardAction {
 export default function DashboardPage() {
   const { user, isAuthenticated, loading } = useAuth()
   const router = useRouter()
+  const { can, canAccessPath, adminRole } = useAdminAccess()
+  const openAdmin = (path: string) => {
+    const pathOnly = path.split('?')[0]
+    if (!canAccessPath(pathOnly)) {
+      toast.error('Your role cannot access that admin area')
+      return
+    }
+    window.open(path, '_blank', 'noopener,noreferrer')
+  }
   const [loyaltyStats, setLoyaltyStats] = useState<LoyaltyStats | null>(null)
   const [approvalStats, setApprovalStats] = useState<ApprovalStats | null>(null)
   const [projectStats, setProjectStats] = useState<ProjectStats | null>(null)
@@ -448,8 +459,22 @@ export default function DashboardPage() {
                 Admin Dashboard
               </h1>
               <p className="text-gray-600">Welcome back, {user?.name}! Manage your platform here.</p>
+              {adminRole && (
+                <p className="mt-1 text-sm text-indigo-700">
+                  Role: {ADMIN_ROLE_LABELS[adminRole as AdminRole] || adminRole}
+                </p>
+              )}
             </div>
             <div className="flex items-center gap-4">
+              {can('staff.manage') && (
+                <Link
+                  className="inline-flex items-center gap-2 rounded-xl border border-indigo-200 bg-white px-4 py-2 text-sm font-semibold text-indigo-700 shadow-sm transition-all duration-200 hover:-translate-y-0.5 hover:shadow-md"
+                  href="/admin/staff"
+                >
+                  <Users className="h-4 w-4" />
+                  Staff & roles
+                </Link>
+              )}
               <Link
                 className="inline-flex items-center gap-2 rounded-xl bg-gradient-to-r from-indigo-600 via-purple-600 to-fuchsia-600 px-4 py-2 text-sm font-semibold text-white shadow-md transition-all duration-200 hover:-translate-y-0.5 hover:shadow-xl"
                 href='/admin/kpi'

--- a/app/(pages)/dashboard/page.tsx
+++ b/app/(pages)/dashboard/page.tsx
@@ -575,7 +575,7 @@ export default function DashboardPage() {
                 {/* Quick Stats */}
                 <Card
                   className="cursor-pointer border-blue-100 bg-gradient-to-br from-white via-blue-50 to-indigo-100 shadow-md transition-all duration-200 hover:-translate-y-1 hover:shadow-xl"
-                  onClick={() => window.open('/admin/projects/approval', '_blank')}
+                  onClick={() => openAdmin('/admin/projects/approval')}
                 >
                   <CardHeader className="pb-2">
                     <CardTitle className="flex items-center gap-2 text-sm">
@@ -635,7 +635,7 @@ export default function DashboardPage() {
 
                 <Card
                   className="cursor-pointer border-rose-100 bg-gradient-to-br from-white via-rose-50 to-orange-100 shadow-md transition-all duration-200 hover:-translate-y-1 hover:shadow-xl"
-                  onClick={() => window.open('/admin/warranty-claims', '_blank')}
+                  onClick={() => openAdmin('/admin/warranty-claims')}
                 >
                   <CardHeader className="pb-2">
                     <CardTitle className="flex items-center gap-2 text-sm">
@@ -675,7 +675,7 @@ export default function DashboardPage() {
                     </div>
                   </div>
                   <Button
-                    onClick={() => window.open('/admin/referral', '_blank')}
+                    onClick={() => openAdmin('/admin/referral')}
                     className="w-full bg-gradient-to-r from-purple-600 to-purple-800 hover:from-purple-700 hover:to-purple-900"
                   >
                     <Gift className="h-4 w-4 mr-2" />
@@ -704,7 +704,7 @@ export default function DashboardPage() {
                     </div>
                   </div>
                   <Button
-                    onClick={() => window.open('/admin/backlinks', '_blank', 'noopener,noreferrer')}
+                    onClick={() => openAdmin('/admin/backlinks')}
                     className="w-full bg-gradient-to-r from-indigo-600 to-blue-700 hover:from-indigo-700 hover:to-blue-800"
                   >
                     <Link2 className="h-4 w-4 mr-2" />
@@ -736,7 +736,7 @@ export default function DashboardPage() {
                     Public ratings update immediately when a review is hidden.
                   </div>
                   <Button
-                    onClick={() => window.open('/admin/reviews', '_blank')}
+                    onClick={() => openAdmin('/admin/reviews')}
                     className="w-full bg-gradient-to-r from-amber-500 to-rose-500 hover:from-amber-600 hover:to-rose-600"
                   >
                     <EyeOff className="h-4 w-4 mr-2" />
@@ -755,7 +755,7 @@ export default function DashboardPage() {
                 </CardHeader>
                 <CardContent>
                   <Button
-                    onClick={() => window.open('/admin/favorites', '_blank')}
+                    onClick={() => openAdmin('/admin/favorites')}
                     className="w-full bg-gradient-to-r from-pink-400 to-purple-500 hover:from-pink-500 hover:to-purple-600"
                   >
                     <Heart className="h-4 w-4 mr-2" />
@@ -774,7 +774,7 @@ export default function DashboardPage() {
                 </CardHeader>
                 <CardContent>
                   <Button
-                    onClick={() => window.open('/admin/settings', '_blank')}
+                    onClick={() => openAdmin('/admin/settings')}
                     className="w-full bg-gradient-to-r from-gray-600 to-gray-800 hover:from-gray-700 hover:to-gray-900"
                   >
                     <Settings className="h-4 w-4 mr-2" />
@@ -793,7 +793,7 @@ export default function DashboardPage() {
                 </CardHeader>
                 <CardContent>
                   <Button
-                    onClick={() => window.open('/admin/cms', '_blank')}
+                    onClick={() => openAdmin('/admin/cms')}
                     className="w-full bg-gradient-to-r from-rose-500 via-pink-500 to-orange-400 hover:from-rose-600 hover:via-pink-600 hover:to-orange-500"
                   >
                     <FileText className="h-4 w-4 mr-2" />
@@ -812,7 +812,7 @@ export default function DashboardPage() {
                 </CardHeader>
                 <CardContent>
                   <Button
-                    onClick={() => window.open('/admin/support', '_blank')}
+                    onClick={() => openAdmin('/admin/support')}
                     className="w-full bg-gradient-to-r from-indigo-500 to-blue-500 hover:from-indigo-600 hover:to-blue-600"
                   >
                     <LifeBuoy className="h-4 w-4 mr-2" />
@@ -831,7 +831,7 @@ export default function DashboardPage() {
                 </CardHeader>
                 <CardContent>
                   <Button
-                    onClick={() => window.open('/admin/discount-codes', '_blank')}
+                    onClick={() => openAdmin('/admin/discount-codes')}
                     className="w-full bg-gradient-to-r from-rose-500 to-orange-500 hover:from-rose-600 hover:to-orange-600"
                   >
                     <Ticket className="h-4 w-4 mr-2" />
@@ -850,7 +850,7 @@ export default function DashboardPage() {
                 </CardHeader>
                 <CardContent>
                   <Button
-                    onClick={() => window.open('/admin/professionals/manage', '_blank')}
+                    onClick={() => openAdmin('/admin/professionals/manage')}
                     className="w-full bg-gradient-to-r from-blue-600 to-cyan-700 hover:from-blue-700 hover:to-cyan-800"
                   >
                     <Briefcase className="h-4 w-4 mr-2" />
@@ -869,7 +869,7 @@ export default function DashboardPage() {
                 </CardHeader>
                 <CardContent>
                   <Button
-                    onClick={() => window.open('/admin/customers', '_blank')}
+                    onClick={() => openAdmin('/admin/customers')}
                     className="w-full bg-gradient-to-r from-emerald-600 to-teal-700 hover:from-emerald-700 hover:to-teal-800"
                   >
                     <Users className="h-4 w-4 mr-2" />
@@ -904,7 +904,7 @@ export default function DashboardPage() {
                     </div>
                   </div>
                   <Button
-                    onClick={() => window.open('/admin/warranty-claims', '_blank')}
+                    onClick={() => openAdmin('/admin/warranty-claims')}
                     className="w-full bg-gradient-to-r from-rose-600 to-orange-600 hover:from-rose-700 hover:to-orange-700"
                   >
                     Open Warranty Claims Dashboard
@@ -922,7 +922,7 @@ export default function DashboardPage() {
                 </CardHeader>
                 <CardContent>
                   <Button
-                    onClick={() => window.open('/admin/bookings', '_blank', 'noopener,noreferrer')}
+                    onClick={() => openAdmin('/admin/bookings')}
                     className="w-full bg-gradient-to-r from-blue-600 to-indigo-700 hover:from-blue-700 hover:to-indigo-800"
                   >
                     Open Booking Management
@@ -940,7 +940,7 @@ export default function DashboardPage() {
                 </CardHeader>
                 <CardContent>
                   <Button
-                    onClick={() => window.open('/admin/disputes', '_blank')}
+                    onClick={() => openAdmin('/admin/disputes')}
                     className="w-full bg-gradient-to-r from-red-600 to-amber-600 hover:from-red-700 hover:to-amber-700"
                   >
                     Open Dispute Dashboard
@@ -958,7 +958,7 @@ export default function DashboardPage() {
                 </CardHeader>
                 <CardContent>
                   <Button
-                    onClick={() => window.open('/admin/cancellation-requests', '_blank')}
+                    onClick={() => openAdmin('/admin/cancellation-requests')}
                     className="w-full bg-gradient-to-r from-amber-600 to-orange-600 hover:from-amber-700 hover:to-orange-700"
                   >
                     Open Cancellation Requests
@@ -976,7 +976,7 @@ export default function DashboardPage() {
                 </CardHeader>
                 <CardContent>
                   <Button
-                    onClick={() => window.open('/admin/chat-reports', '_blank')}
+                    onClick={() => openAdmin('/admin/chat-reports')}
                     className="w-full bg-gradient-to-r from-purple-600 to-pink-600 hover:from-purple-700 hover:to-pink-700"
                   >
                     Open Reported Chats
@@ -994,7 +994,7 @@ export default function DashboardPage() {
                 </CardHeader>
                 <CardContent>
                   <Button
-                    onClick={() => window.open('/admin/audit-logs', '_blank', 'noopener,noreferrer')}
+                    onClick={() => openAdmin('/admin/audit-logs')}
                     className="w-full bg-gradient-to-r from-slate-600 to-zinc-700 hover:from-slate-700 hover:to-zinc-800"
                   >
                     Open Audit Logs
@@ -1148,14 +1148,14 @@ export default function DashboardPage() {
                   </p>
                   <div className="grid md:grid-cols-2 gap-4">
                     <Button
-                      onClick={() => window.open('/admin/services', '_blank')}
+                      onClick={() => openAdmin('/admin/services')}
                       className="w-full bg-gradient-to-r from-purple-500 to-pink-500 hover:from-purple-600 hover:to-pink-600"
                     >
                       <Package className="h-4 w-4 mr-2" />
                       Manage Service Configurations
                     </Button>
                     <Button
-                      onClick={() => window.open('/admin/services', '_blank')}
+                      onClick={() => openAdmin('/admin/services')}
                       variant="outline"
                       className="w-full border-purple-200 hover:bg-purple-50"
                     >
@@ -1228,7 +1228,7 @@ export default function DashboardPage() {
                     <CardDescription>Manage loyalty tiers, discounts, and points rewards</CardDescription>
                   </CardHeader>
                   <CardContent className="space-y-4">
-                    <Button onClick={() => window.open('/admin/loyalty/config', '_blank')} className="w-full">
+                    <Button onClick={() => openAdmin('/admin/loyalty/config')} className="w-full">
                       Configure Loyalty And Points
                     </Button>
                     <Button
@@ -1257,7 +1257,7 @@ export default function DashboardPage() {
                     <CardDescription>Configure level thresholds, perks, and points boost rules</CardDescription>
                   </CardHeader>
                   <CardContent className="space-y-4">
-                    <Button onClick={() => window.open('/admin/professional-levels/config', '_blank')} className="w-full">
+                    <Button onClick={() => openAdmin('/admin/professional-levels/config')} className="w-full">
                       Configure Professional Levels
                     </Button>
                     <Button
@@ -1357,14 +1357,14 @@ export default function DashboardPage() {
                 <CardContent className="space-y-4">
                   <div className="grid md:grid-cols-2 gap-4">
                     <Button 
-                      onClick={() => window.open('/admin/professionals?status=pending', '_blank')}
+                      onClick={() => openAdmin('/admin/professionals?status=pending')}
                       className="w-full"
                       variant={approvalStats?.pending ? 'default' : 'outline'}
                     >
                       Review Pending ({approvalStats?.pending || 0})
                     </Button>
                     <Button 
-                      onClick={() => window.open('/admin/professionals?status=approved', '_blank')}
+                      onClick={() => openAdmin('/admin/professionals?status=approved')}
                       variant="outline"
                       className="w-full"
                     >
@@ -1373,14 +1373,14 @@ export default function DashboardPage() {
                   </div>
                   <div className="grid md:grid-cols-2 gap-4">
                     <Button 
-                      onClick={() => window.open('/admin/professionals?status=rejected', '_blank')}
+                      onClick={() => openAdmin('/admin/professionals?status=rejected')}
                       variant="outline"
                       className="w-full"
                     >
                       View Rejected ({approvalStats?.rejected || 0})
                     </Button>
                     <Button 
-                      onClick={() => window.open('/admin/professionals?status=suspended', '_blank')}
+                      onClick={() => openAdmin('/admin/professionals?status=suspended')}
                       variant="outline"
                       className="w-full"
                     >
@@ -1407,14 +1407,14 @@ export default function DashboardPage() {
                   </p>
                   <div className="grid md:grid-cols-2 gap-4">
                     <Button
-                      onClick={() => window.open('/admin/payments', '_blank')}
+                      onClick={() => openAdmin('/admin/payments')}
                       className="w-full bg-gradient-to-r from-blue-500 to-indigo-500 hover:from-blue-600 hover:to-indigo-600"
                     >
                       <CreditCard className="h-4 w-4 mr-2" />
                       View All Payments
                     </Button>
                     <Button
-                      onClick={() => window.open('/admin/payments?status=authorized', '_blank')}
+                      onClick={() => openAdmin('/admin/payments?status=authorized')}
                       variant="outline"
                       className="w-full border-amber-200 hover:bg-amber-50"
                     >

--- a/components/admin/AdminAccessGate.tsx
+++ b/components/admin/AdminAccessGate.tsx
@@ -1,0 +1,45 @@
+'use client';
+
+import { useEffect } from 'react';
+import { usePathname, useRouter } from 'next/navigation';
+import { useAuth } from '@/contexts/AuthContext';
+import { useAdminAccess } from '@/hooks/useAdminAccess';
+
+const PUBLIC_ADMIN_PATHS = ['/admin/accept-invite'];
+
+export default function AdminAccessGate({ children }: { children: React.ReactNode }) {
+  const pathname = usePathname();
+  const router = useRouter();
+  const { loading, isAuthenticated } = useAuth();
+  const { isAdmin, canAccessPath } = useAdminAccess();
+
+  const isPublicAdminPath = PUBLIC_ADMIN_PATHS.some(
+    (path) => pathname === path || pathname?.startsWith(`${path}/`)
+  );
+
+  useEffect(() => {
+    if (isPublicAdminPath) return;
+    if (loading) return;
+    if (!isAuthenticated || !isAdmin) {
+      router.replace(`/login?redirect=${encodeURIComponent(pathname || '/admin')}`);
+      return;
+    }
+    if (!canAccessPath(pathname || '')) {
+      router.replace('/dashboard');
+    }
+  }, [loading, isAuthenticated, isAdmin, canAccessPath, pathname, router, isPublicAdminPath]);
+
+  if (isPublicAdminPath) {
+    return <>{children}</>;
+  }
+
+  if (loading || !isAuthenticated || !isAdmin || !canAccessPath(pathname || '')) {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-slate-50 text-sm text-gray-500">
+        Checking admin access…
+      </div>
+    );
+  }
+
+  return <>{children}</>;
+}

--- a/components/admin/RequireAdminPermission.tsx
+++ b/components/admin/RequireAdminPermission.tsx
@@ -1,0 +1,42 @@
+'use client';
+
+import { useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+import { useAuth } from '@/contexts/AuthContext';
+import { useAdminAccess } from '@/hooks/useAdminAccess';
+import type { AdminPermission } from '@/lib/adminRbac';
+
+export function RequireAdminPermission({
+  permission,
+  children,
+  fallbackPath = '/dashboard',
+}: {
+  permission: AdminPermission;
+  children: React.ReactNode;
+  fallbackPath?: string;
+}) {
+  const { loading, isAuthenticated } = useAuth();
+  const { isAdmin, can } = useAdminAccess();
+  const router = useRouter();
+
+  useEffect(() => {
+    if (loading) return;
+    if (!isAuthenticated || !isAdmin) {
+      router.replace(`/login?redirect=${encodeURIComponent(typeof window !== 'undefined' ? window.location.pathname : '/dashboard')}`);
+      return;
+    }
+    if (!can(permission)) {
+      router.replace(fallbackPath);
+    }
+  }, [loading, isAuthenticated, isAdmin, can, permission, router, fallbackPath]);
+
+  if (loading || !isAuthenticated || !isAdmin || !can(permission)) {
+    return (
+      <div className="flex min-h-[40vh] items-center justify-center text-sm text-gray-500">
+        Checking access…
+      </div>
+    );
+  }
+
+  return <>{children}</>;
+}

--- a/contexts/AuthContext.tsx
+++ b/contexts/AuthContext.tsx
@@ -3,7 +3,7 @@ import React, { createContext, useContext, useEffect, useRef, useState } from 'r
 import { usePathname, useRouter } from 'next/navigation'
 import { toast } from 'sonner'
 import { getAuthToken, setAuthToken } from '@/lib/utils'
-import type { AdminRole } from '@/lib/adminRbac'
+import type { AdminPermission, AdminRole } from '@/lib/adminRbac'
 import { ONBOARDING_STEPS } from '@/lib/constants/onboardingSteps'
 import { PENDING_FAVORITE_KEY, LEGACY_PENDING_FAVORITE_KEY } from '@/lib/constants/favorites'
 import { getMigratedItem, removeMigratedItem } from '@/lib/storageMigration'
@@ -15,7 +15,7 @@ interface User {
   phone: string
   role: 'admin' | 'visitor' | 'customer' | 'professional' | 'employee'
   adminRole?: AdminRole
-  adminPermissions?: string[]
+  adminPermissions?: AdminPermission[]
   isEmailVerified: boolean
   isPhoneVerified: boolean
   vatNumber?: string

--- a/contexts/AuthContext.tsx
+++ b/contexts/AuthContext.tsx
@@ -3,6 +3,7 @@ import React, { createContext, useContext, useEffect, useRef, useState } from 'r
 import { usePathname, useRouter } from 'next/navigation'
 import { toast } from 'sonner'
 import { getAuthToken, setAuthToken } from '@/lib/utils'
+import type { AdminRole } from '@/lib/adminRbac'
 import { ONBOARDING_STEPS } from '@/lib/constants/onboardingSteps'
 import { PENDING_FAVORITE_KEY, LEGACY_PENDING_FAVORITE_KEY } from '@/lib/constants/favorites'
 import { getMigratedItem, removeMigratedItem } from '@/lib/storageMigration'
@@ -13,7 +14,7 @@ interface User {
   email: string
   phone: string
   role: 'admin' | 'visitor' | 'customer' | 'professional' | 'employee'
-  adminRole?: 'super' | 'care' | 'marketing' | 'quality' | 'finance'
+  adminRole?: AdminRole
   adminPermissions?: string[]
   isEmailVerified: boolean
   isPhoneVerified: boolean

--- a/contexts/AuthContext.tsx
+++ b/contexts/AuthContext.tsx
@@ -13,6 +13,8 @@ interface User {
   email: string
   phone: string
   role: 'admin' | 'visitor' | 'customer' | 'professional' | 'employee'
+  adminRole?: 'super' | 'care' | 'marketing' | 'quality' | 'finance'
+  adminPermissions?: string[]
   isEmailVerified: boolean
   isPhoneVerified: boolean
   vatNumber?: string
@@ -185,6 +187,7 @@ const ROUTE_CONFIG = {
     '/forgot-password',
     '/reset-password',
     '/signup',
+    '/admin/accept-invite',
   ],
 
   // Protected routes - require authentication (any role)

--- a/hooks/useAdminAccess.ts
+++ b/hooks/useAdminAccess.ts
@@ -1,0 +1,35 @@
+'use client';
+
+import { useMemo } from 'react';
+import { useAuth } from '@/contexts/AuthContext';
+import {
+  hasAdminPermission,
+  permissionForAdminPage,
+  type AdminPermission,
+  type AdminRole,
+} from '@/lib/adminRbac';
+
+export function useAdminAccess() {
+  const { user, isAuthenticated } = useAuth();
+  const isAdmin = isAuthenticated && user?.role === 'admin';
+  const adminRole = (user?.adminRole as AdminRole | undefined) || (isAdmin ? 'super' : undefined);
+  const permissions = (user?.adminPermissions as AdminPermission[] | undefined) || [];
+
+  const can = useMemo(() => {
+    return (permission: AdminPermission) => {
+      if (!isAdmin) return false;
+      // Legacy sessions without permissions payload → treat as super until refresh
+      if (!user?.adminPermissions) return true;
+      return hasAdminPermission(permissions, permission);
+    };
+  }, [isAdmin, permissions, user?.adminPermissions]);
+
+  const canAccessPath = (pathname: string) => {
+    if (!isAdmin) return false;
+    const required = permissionForAdminPage(pathname);
+    if (!required) return true;
+    return can(required);
+  };
+
+  return { isAdmin, adminRole, permissions, can, canAccessPath };
+}

--- a/hooks/useAdminAccess.ts
+++ b/hooks/useAdminAccess.ts
@@ -11,17 +11,21 @@ import {
 export function useAdminAccess() {
   const { user, isAuthenticated } = useAuth();
   const isAdmin = isAuthenticated && user?.role === 'admin';
-  const adminRole = user?.adminRole || (isAdmin ? 'super' : undefined);
-  const permissions = user?.adminPermissions || [];
+  // Do not invent 'super' — missing role means incomplete session payload
+  const adminRole = user?.adminRole;
+  const permissions = user?.adminPermissions;
 
   const can = useMemo(() => {
     return (permission: AdminPermission) => {
       if (!isAdmin) return false;
-      // Legacy sessions without permissions payload → treat as super until refresh
-      if (!user?.adminPermissions) return true;
+      // Fail closed: missing permissions payload must not grant all access.
+      // Explicit super may keep a legacy fallback until /me refreshes the pack.
+      if (!permissions) {
+        return user?.adminRole === 'super';
+      }
       return hasAdminPermission(permissions, permission);
     };
-  }, [isAdmin, permissions, user?.adminPermissions]);
+  }, [isAdmin, permissions, user?.adminRole]);
 
   const canAccessPath = (pathname: string) => {
     if (!isAdmin) return false;
@@ -30,5 +34,5 @@ export function useAdminAccess() {
     return can(required);
   };
 
-  return { isAdmin, adminRole, permissions, can, canAccessPath };
+  return { isAdmin, adminRole, permissions: permissions || [], can, canAccessPath };
 }

--- a/hooks/useAdminAccess.ts
+++ b/hooks/useAdminAccess.ts
@@ -6,14 +6,13 @@ import {
   hasAdminPermission,
   permissionForAdminPage,
   type AdminPermission,
-  type AdminRole,
 } from '@/lib/adminRbac';
 
 export function useAdminAccess() {
   const { user, isAuthenticated } = useAuth();
   const isAdmin = isAuthenticated && user?.role === 'admin';
-  const adminRole = (user?.adminRole as AdminRole | undefined) || (isAdmin ? 'super' : undefined);
-  const permissions = (user?.adminPermissions as AdminPermission[] | undefined) || [];
+  const adminRole = user?.adminRole || (isAdmin ? 'super' : undefined);
+  const permissions = user?.adminPermissions || [];
 
   const can = useMemo(() => {
     return (permission: AdminPermission) => {

--- a/lib/adminRbac.ts
+++ b/lib/adminRbac.ts
@@ -1,0 +1,131 @@
+export const ADMIN_ROLES = ['super', 'care', 'marketing', 'quality', 'finance'] as const;
+export type AdminRole = (typeof ADMIN_ROLES)[number];
+
+export type AdminPermission =
+  | 'staff.manage'
+  | 'dashboard.overview'
+  | 'professionals.approve'
+  | 'professionals.manage'
+  | 'customers.manage'
+  | 'bookings.read'
+  | 'bookings.write'
+  | 'disputes.manage'
+  | 'cancellations.manage'
+  | 'chat.support'
+  | 'chat.reports'
+  | 'support.tickets'
+  | 'payments.manage'
+  | 'kpi.read'
+  | 'audit.read'
+  | 'email_logs.read'
+  | 'cms.manage'
+  | 'discounts.manage'
+  | 'loyalty.manage'
+  | 'referrals.manage'
+  | 'backlinks.manage'
+  | 'reviews.moderate'
+  | 'favorites.manage'
+  | 'services.manage'
+  | 'projects.approve'
+  | 'warranty.manage'
+  | 'settings.platform'
+  | 'settings.site'
+  | 'maintenance.run'
+  | 'users.delete';
+
+/** Path → permission for client-side route gating (keep aligned with server routePermissions). */
+export const ADMIN_PAGE_PERMISSIONS: Array<{ prefix: string; permission: AdminPermission }> = [
+  { prefix: '/admin/staff', permission: 'staff.manage' },
+  { prefix: '/admin/professionals/manage', permission: 'professionals.manage' },
+  { prefix: '/admin/professionals', permission: 'professionals.approve' },
+  { prefix: '/admin/customers', permission: 'customers.manage' },
+  { prefix: '/admin/bookings', permission: 'bookings.read' },
+  { prefix: '/admin/disputes', permission: 'disputes.manage' },
+  { prefix: '/admin/cancellation-requests', permission: 'cancellations.manage' },
+  { prefix: '/admin/chat-reports', permission: 'chat.reports' },
+  { prefix: '/admin/chat', permission: 'chat.support' },
+  { prefix: '/admin/support', permission: 'support.tickets' },
+  { prefix: '/admin/payments', permission: 'payments.manage' },
+  { prefix: '/admin/kpi', permission: 'kpi.read' },
+  { prefix: '/admin/audit-logs', permission: 'audit.read' },
+  { prefix: '/admin/cms', permission: 'cms.manage' },
+  { prefix: '/admin/discount-codes', permission: 'discounts.manage' },
+  { prefix: '/admin/loyalty', permission: 'loyalty.manage' },
+  { prefix: '/admin/professional-levels', permission: 'loyalty.manage' },
+  { prefix: '/admin/referral', permission: 'referrals.manage' },
+  { prefix: '/admin/backlinks', permission: 'backlinks.manage' },
+  { prefix: '/admin/favorites', permission: 'favorites.manage' },
+  { prefix: '/admin/reviews', permission: 'reviews.moderate' },
+  { prefix: '/admin/services', permission: 'services.manage' },
+  { prefix: '/admin/projects', permission: 'projects.approve' },
+  { prefix: '/admin/warranty-claims', permission: 'warranty.manage' },
+  { prefix: '/admin/settings', permission: 'settings.platform' },
+  { prefix: '/admin/site-announcements', permission: 'cms.manage' },
+];
+
+export const ADMIN_ROLE_LABELS: Record<AdminRole, string> = {
+  super: 'Super admin',
+  care: 'Customer care',
+  marketing: 'Marketing',
+  quality: 'Quality',
+  finance: 'Finance',
+};
+
+/** Human-readable admin areas each role can open (keep aligned with server ROLE_PERMISSIONS). */
+export const ADMIN_ROLE_ACCESS: Record<AdminRole, string[]> = {
+  super: [
+    'Everything below',
+    'Staff & roles',
+    'Platform / site settings',
+    'Maintenance jobs',
+    'User delete / anonymize',
+  ],
+  care: [
+    'Bookings',
+    'Disputes',
+    'Cancellations',
+    'Support chat',
+    'Support tickets',
+    'Chat reports',
+    'Customers',
+    'Warranty claims',
+  ],
+  marketing: [
+    'CMS',
+    'Discount codes',
+    'Loyalty & points',
+    'Referrals',
+    'Backlinks',
+    'Favorites',
+  ],
+  quality: [
+    'Professional approvals',
+    'Professional management',
+    'Project approvals',
+    'Review moderation',
+    'Chat reports',
+    'Warranty claims',
+    'Services',
+  ],
+  finance: [
+    'Payments',
+    'KPI dashboard',
+    'Audit logs',
+    'Email logs',
+    'Bookings (read only)',
+  ],
+};
+
+export function permissionForAdminPage(pathname: string): AdminPermission | null {
+  const match = ADMIN_PAGE_PERMISSIONS.find(
+    (rule) => pathname === rule.prefix || pathname.startsWith(`${rule.prefix}/`)
+  );
+  return match?.permission ?? null;
+}
+
+export function hasAdminPermission(
+  permissions: AdminPermission[] | undefined | null,
+  permission: AdminPermission
+): boolean {
+  return Boolean(permissions?.includes(permission));
+}

--- a/lib/adminRbac.ts
+++ b/lib/adminRbac.ts
@@ -116,6 +116,22 @@ export const ADMIN_ROLE_ACCESS: Record<AdminRole, string[]> = {
   ],
 };
 
+/** Area → roles matrix derived from ADMIN_ROLE_ACCESS (single source of truth). */
+export const ADMIN_ACCESS_MATRIX: Array<{ area: string; roles: AdminRole[] }> = (() => {
+  const byArea = new Map<string, Set<AdminRole>>();
+  for (const role of ADMIN_ROLES) {
+    for (const area of ADMIN_ROLE_ACCESS[role]) {
+      if (area === 'Everything below') continue;
+      if (!byArea.has(area)) byArea.set(area, new Set<AdminRole>(['super']));
+      byArea.get(area)!.add(role);
+    }
+  }
+  return Array.from(byArea.entries()).map(([area, roles]) => ({
+    area,
+    roles: ADMIN_ROLES.filter((r) => roles.has(r)),
+  }));
+})();
+
 export function permissionForAdminPage(pathname: string): AdminPermission | null {
   const match = ADMIN_PAGE_PERMISSIONS.find(
     (rule) => pathname === rule.prefix || pathname.startsWith(`${rule.prefix}/`)

--- a/lib/apiErrors.ts
+++ b/lib/apiErrors.ts
@@ -1,0 +1,24 @@
+export type ApiErrorBody = {
+  success?: boolean;
+  msg?: string;
+  message?: string;
+  error?: string;
+  field?: 'email' | 'phone' | 'name' | string;
+};
+
+export function messageFromApiBody(body: ApiErrorBody | null | undefined, fallback: string): string {
+  if (!body) return fallback;
+  return body.msg?.trim() || body.message?.trim() || body.error?.trim() || fallback;
+}
+
+export async function readJsonResponse<T = ApiErrorBody>(res: Response): Promise<T & ApiErrorBody> {
+  const text = await res.text();
+  if (!text.trim()) {
+    return {} as T & ApiErrorBody;
+  }
+  try {
+    return JSON.parse(text) as T & ApiErrorBody;
+  } catch {
+    throw new Error(`Invalid server response (${res.status})`);
+  }
+}

--- a/lib/apiErrors.ts
+++ b/lib/apiErrors.ts
@@ -6,9 +6,18 @@ export type ApiErrorBody = {
   field?: 'email' | 'phone' | 'name' | string;
 };
 
+function asTrimmedString(value: unknown): string | undefined {
+  return typeof value === 'string' ? value.trim() || undefined : undefined;
+}
+
 export function messageFromApiBody(body: ApiErrorBody | null | undefined, fallback: string): string {
-  if (!body) return fallback;
-  return body.msg?.trim() || body.message?.trim() || body.error?.trim() || fallback;
+  if (!body || typeof body !== 'object') return fallback;
+  return (
+    asTrimmedString(body.msg) ||
+    asTrimmedString(body.message) ||
+    asTrimmedString(body.error) ||
+    fallback
+  );
 }
 
 export async function readJsonResponse<T = ApiErrorBody>(res: Response): Promise<T & ApiErrorBody> {
@@ -17,8 +26,15 @@ export async function readJsonResponse<T = ApiErrorBody>(res: Response): Promise
     return {} as T & ApiErrorBody;
   }
   try {
-    return JSON.parse(text) as T & ApiErrorBody;
-  } catch {
+    const parsed: unknown = JSON.parse(text);
+    if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      throw new Error(`Invalid server response (${res.status})`);
+    }
+    return parsed as T & ApiErrorBody;
+  } catch (err) {
+    if (err instanceof Error && err.message.startsWith('Invalid server response')) {
+      throw err;
+    }
     throw new Error(`Invalid server response (${res.status})`);
   }
 }


### PR DESCRIPTION
## Summary
- Gate admin pages by role permissions and add staff management UI.
- Add `/admin/accept-invite` page for invited admins to set their password.
- Show pending invite status and copyable invite link fallback in staff UI.

## Test plan
- [x] `npm run build`
- [ ] Super admin can invite staff and copy invite link when email is unavailable
- [ ] Invited admin can activate account via link and land on dashboard
- [ ] Non-super roles are blocked from staff management and restricted admin areas

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an admin invite acceptance page with token lookup, password setup (with validation), and automatic sign-in.
  * Introduced an admin Staff & roles management page (invite, resend invites, role assignment, suspend/reactivate, and role access overview).
* **Improvements**
  * Enhanced admin access control across the app, including safer admin link opening and permission-based visibility of admin navigation.
* **Bug Fixes**
  * Improved handling of API error responses to surface clearer user-friendly messages.
* **Chores**
  * Ignored demo video assets in version control.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->