### PR TITLE
Point 11: close admin dashboard UI gaps

### DIFF
--- a/app/(pages)/admin/audit-logs/page.tsx
+++ b/app/(pages)/admin/audit-logs/page.tsx
@@ -228,6 +228,12 @@ export default function AdminAuditLogsPage() {
     setExporting(format)
     try {
       const params = new URLSearchParams(filterParams)
+      const trimmedActorEmail = actorEmail.trim()
+      if (trimmedActorEmail.length >= 2) {
+        params.set('actorEmail', trimmedActorEmail)
+      } else {
+        params.delete('actorEmail')
+      }
       if (format === 'json') params.set('format', 'json')
       const res = await authFetch(
         `${process.env.NEXT_PUBLIC_BACKEND_URL}/api/admin/audit-logs/export?${params.toString()}`
@@ -253,7 +259,7 @@ export default function AdminAuditLogsPage() {
     } finally {
       setExporting(null)
     }
-  }, [filterParams])
+  }, [filterParams, actorEmail])
 
   if (loading || !user) return null
   if (user.role !== 'admin') return null

--- a/app/(pages)/admin/audit-logs/page.tsx
+++ b/app/(pages)/admin/audit-logs/page.tsx
@@ -24,7 +24,7 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog"
 import { Skeleton } from "@/components/ui/skeleton"
-import { ClipboardList, RefreshCw, X } from "lucide-react"
+import { ClipboardList, Download, RefreshCw, X } from "lucide-react"
 import { toast } from "sonner"
 
 interface AuditLog {
@@ -52,8 +52,7 @@ interface AuditStats {
   uniqueActors: number
 }
 
-const KNOWN_ACTIONS = [
-  'all',
+const FALLBACK_ACTIONS = [
   'admin.professionals.approve',
   'admin.professionals.reject',
   'admin.professionals.suspend',
@@ -68,7 +67,7 @@ const KNOWN_ACTIONS = [
   'user.anonymize',
 ]
 
-const TARGET_TYPES = ['all', 'User', 'Booking', 'Payment', 'WarrantyClaim', 'CancellationRequest', 'Referral']
+const FALLBACK_TARGET_TYPES = ['User', 'Booking', 'Payment', 'WarrantyClaim', 'CancellationRequest', 'Referral']
 
 const STATUSES: Array<'all' | 'success' | 'failure'> = ['all', 'success', 'failure']
 
@@ -81,6 +80,10 @@ export default function AdminAuditLogsPage() {
   const [isLoading, setIsLoading] = useState(true)
   const [page, setPage] = useState(1)
   const [totalPages, setTotalPages] = useState(1)
+  const [exporting, setExporting] = useState<'csv' | 'json' | null>(null)
+
+  const [actionOptions, setActionOptions] = useState<string[]>(FALLBACK_ACTIONS)
+  const [targetTypeOptions, setTargetTypeOptions] = useState<string[]>(FALLBACK_TARGET_TYPES)
 
   const [actionFilter, setActionFilter] = useState<string>('all')
   const [targetTypeFilter, setTargetTypeFilter] = useState<string>('all')
@@ -113,16 +116,42 @@ export default function AdminAuditLogsPage() {
     }
   }, [actorEmail])
 
-  const queryString = useMemo(() => {
-    const params = new URLSearchParams({ page: page.toString(), limit: '25' })
+  useEffect(() => {
+    if (user?.role !== 'admin') return
+    let cancelled = false
+    ;(async () => {
+      try {
+        const res = await authFetch(`${process.env.NEXT_PUBLIC_BACKEND_URL}/api/admin/audit-logs/actions`)
+        const json = await res.json()
+        if (cancelled || !res.ok || !json?.success) return
+        const actions = Array.isArray(json.data?.actions) ? json.data.actions.filter(Boolean) : []
+        const targetTypes = Array.isArray(json.data?.targetTypes) ? json.data.targetTypes.filter(Boolean) : []
+        if (actions.length > 0) setActionOptions(actions)
+        if (targetTypes.length > 0) setTargetTypeOptions(targetTypes)
+      } catch {
+        // keep fallback lists
+      }
+    })()
+    return () => { cancelled = true }
+  }, [user])
+
+  const filterParams = useMemo(() => {
+    const params = new URLSearchParams()
     if (actionFilter !== 'all') params.set('action', actionFilter)
     if (targetTypeFilter !== 'all') params.set('targetType', targetTypeFilter)
     if (statusFilter !== 'all') params.set('status', statusFilter)
     if (debouncedActorEmail.length >= 2) params.set('actorEmail', debouncedActorEmail)
     if (fromDate) params.set('from', fromDate)
     if (untilDate) params.set('until', untilDate)
+    return params
+  }, [actionFilter, targetTypeFilter, statusFilter, debouncedActorEmail, fromDate, untilDate])
+
+  const queryString = useMemo(() => {
+    const params = new URLSearchParams(filterParams)
+    params.set('page', page.toString())
+    params.set('limit', '25')
     return params.toString()
-  }, [page, actionFilter, targetTypeFilter, statusFilter, debouncedActorEmail, fromDate, untilDate])
+  }, [page, filterParams])
 
   const statsQueryString = useMemo(() => {
     const params = new URLSearchParams()
@@ -195,13 +224,44 @@ export default function AdminAuditLogsPage() {
     }
   }, [])
 
+  const exportLogs = useCallback(async (format: 'csv' | 'json') => {
+    setExporting(format)
+    try {
+      const params = new URLSearchParams(filterParams)
+      if (format === 'json') params.set('format', 'json')
+      const res = await authFetch(
+        `${process.env.NEXT_PUBLIC_BACKEND_URL}/api/admin/audit-logs/export?${params.toString()}`
+      )
+      if (!res.ok) {
+        const json = await res.json().catch(() => ({}))
+        toast.error(json?.msg || 'Failed to export audit logs')
+        return
+      }
+      const blob = await res.blob()
+      const stamp = new Date().toISOString().slice(0, 10)
+      const objectUrl = URL.createObjectURL(blob)
+      const a = document.createElement('a')
+      a.href = objectUrl
+      a.download = `audit-logs-${stamp}.${format}`
+      document.body.appendChild(a)
+      a.click()
+      document.body.removeChild(a)
+      URL.revokeObjectURL(objectUrl)
+      toast.success(`Exported audit logs (${format.toUpperCase()})`)
+    } catch {
+      toast.error('Failed to export audit logs')
+    } finally {
+      setExporting(null)
+    }
+  }, [filterParams])
+
   if (loading || !user) return null
   if (user.role !== 'admin') return null
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-blue-50 via-indigo-50 to-pink-50 p-4">
       <div className="max-w-6xl mx-auto pt-20 space-y-6">
-        <div className="flex items-center justify-between">
+        <div className="flex items-center justify-between flex-wrap gap-3">
           <div>
             <h1 className="text-2xl font-bold text-gray-900 flex items-center gap-2">
               <ClipboardList className="h-6 w-6" />
@@ -209,10 +269,30 @@ export default function AdminAuditLogsPage() {
             </h1>
             <p className="text-sm text-gray-500 mt-1">Every state-changing admin and account action</p>
           </div>
-          <Button variant="outline" size="sm" onClick={() => { fetchLogs(); fetchStats() }}>
-            <RefreshCw className="h-4 w-4 mr-2" />
-            Refresh
-          </Button>
+          <div className="flex gap-2 flex-wrap">
+            <Button
+              variant="outline"
+              size="sm"
+              disabled={!!exporting}
+              onClick={() => exportLogs('csv')}
+            >
+              <Download className="h-4 w-4 mr-2" />
+              {exporting === 'csv' ? 'Exporting…' : 'Export CSV'}
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              disabled={!!exporting}
+              onClick={() => exportLogs('json')}
+            >
+              <Download className="h-4 w-4 mr-2" />
+              {exporting === 'json' ? 'Exporting…' : 'Export JSON'}
+            </Button>
+            <Button variant="outline" size="sm" onClick={() => { fetchLogs(); fetchStats() }}>
+              <RefreshCw className="h-4 w-4 mr-2" />
+              Refresh
+            </Button>
+          </div>
         </div>
 
         {stats && (
@@ -248,8 +328,9 @@ export default function AdminAuditLogsPage() {
                     <SelectValue />
                   </SelectTrigger>
                   <SelectContent>
-                    {KNOWN_ACTIONS.map((a) => (
-                      <SelectItem key={a} value={a}>{a === 'all' ? 'All actions' : a}</SelectItem>
+                    <SelectItem value="all">All actions</SelectItem>
+                    {actionOptions.map((a) => (
+                      <SelectItem key={a} value={a}>{a}</SelectItem>
                     ))}
                   </SelectContent>
                 </Select>
@@ -262,8 +343,9 @@ export default function AdminAuditLogsPage() {
                     <SelectValue />
                   </SelectTrigger>
                   <SelectContent>
-                    {TARGET_TYPES.map((t) => (
-                      <SelectItem key={t} value={t}>{t === 'all' ? 'All targets' : t}</SelectItem>
+                    <SelectItem value="all">All targets</SelectItem>
+                    {targetTypeOptions.map((t) => (
+                      <SelectItem key={t} value={t}>{t}</SelectItem>
                     ))}
                   </SelectContent>
                 </Select>

--- a/app/(pages)/admin/audit-logs/page.tsx
+++ b/app/(pages)/admin/audit-logs/page.tsx
@@ -153,15 +153,7 @@ export default function AdminAuditLogsPage() {
     return params.toString()
   }, [page, filterParams])
 
-  const statsQueryString = useMemo(() => {
-    const params = new URLSearchParams()
-    if (actionFilter !== 'all') params.set('action', actionFilter)
-    if (targetTypeFilter !== 'all') params.set('targetType', targetTypeFilter)
-    if (statusFilter !== 'all') params.set('status', statusFilter)
-    if (fromDate) params.set('from', fromDate)
-    if (untilDate) params.set('until', untilDate)
-    return params.toString()
-  }, [actionFilter, targetTypeFilter, statusFilter, fromDate, untilDate])
+  const statsQueryString = useMemo(() => filterParams.toString(), [filterParams])
 
   const fetchLogs = useCallback(async () => {
     logsAbortRef.current?.abort()

--- a/app/(pages)/admin/bookings/[id]/page.tsx
+++ b/app/(pages)/admin/bookings/[id]/page.tsx
@@ -188,20 +188,24 @@ export default function AdminBookingDetailPage() {
 
   const viewCustomerProChat = useCallback(async () => {
     if (!id) return
+    const chatWindow = window.open('about:blank', '_blank')
     setOpeningProChat(true)
     try {
       const res = await authFetch(`${process.env.NEXT_PUBLIC_BACKEND_URL}/api/admin/bookings/${id}/conversation`)
       const json = await res.json()
       if (!res.ok || !json?.success || !json?.data?.conversationId) {
+        chatWindow?.close()
         toast.error(json?.msg || 'No customer↔professional chat found for this booking')
         return
       }
-      window.open(
-        `/admin/chat?${new URLSearchParams({ conversationId: json.data.conversationId }).toString()}`,
-        '_blank',
-        'noopener'
-      )
+      const url = `/admin/chat?${new URLSearchParams({ conversationId: json.data.conversationId }).toString()}`
+      if (chatWindow) {
+        chatWindow.location.href = url
+      } else {
+        window.open(url, '_blank', 'noopener')
+      }
     } catch {
+      chatWindow?.close()
       toast.error('Failed to open customer↔professional chat')
     } finally {
       setOpeningProChat(false)

--- a/app/(pages)/admin/bookings/[id]/page.tsx
+++ b/app/(pages)/admin/bookings/[id]/page.tsx
@@ -98,6 +98,7 @@ export default function AdminBookingDetailPage() {
   const [forceStatusValue, setForceStatusValue] = useState("")
   const [forcingStatus, setForcingStatus] = useState(false)
   const [startingChat, setStartingChat] = useState<'customer' | 'professional' | null>(null)
+  const [openingProChat, setOpeningProChat] = useState(false)
 
   useEffect(() => {
     if (!loading && (!user || user.role !== 'admin')) {
@@ -185,6 +186,28 @@ export default function AdminBookingDetailPage() {
     }
   }, [data])
 
+  const viewCustomerProChat = useCallback(async () => {
+    if (!id) return
+    setOpeningProChat(true)
+    try {
+      const res = await authFetch(`${process.env.NEXT_PUBLIC_BACKEND_URL}/api/admin/bookings/${id}/conversation`)
+      const json = await res.json()
+      if (!res.ok || !json?.success || !json?.data?.conversationId) {
+        toast.error(json?.msg || 'No customer↔professional chat found for this booking')
+        return
+      }
+      window.open(
+        `/admin/chat?${new URLSearchParams({ conversationId: json.data.conversationId }).toString()}`,
+        '_blank',
+        'noopener'
+      )
+    } catch {
+      toast.error('Failed to open customer↔professional chat')
+    } finally {
+      setOpeningProChat(false)
+    }
+  }, [id])
+
   if (loading || !user) return null
 
   return (
@@ -251,6 +274,15 @@ export default function AdminBookingDetailPage() {
                   >
                     <MessageSquare className="h-4 w-4 mr-1" />
                     {startingChat === 'professional' ? 'Opening…' : 'Chat professional'}
+                  </Button>
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    disabled={openingProChat}
+                    onClick={viewCustomerProChat}
+                  >
+                    <MessageSquare className="h-4 w-4 mr-1" />
+                    {openingProChat ? 'Opening…' : 'View customer↔pro chat'}
                   </Button>
                 </div>
                 <div className="flex flex-wrap items-center gap-2 pt-3 border-t mt-3">

--- a/app/(pages)/admin/chat-reports/page.tsx
+++ b/app/(pages)/admin/chat-reports/page.tsx
@@ -340,7 +340,19 @@ export default function AdminChatReportsPage() {
                 />
               </div>
 
-              <div className="flex justify-end gap-2">
+              <div className="flex justify-end gap-2 flex-wrap">
+                {drawerReport?.conversationId?._id && (
+                  <Button variant="outline" asChild>
+                    <a
+                      href={`/admin/chat?conversationId=${drawerReport.conversationId._id}`}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                    >
+                      <MessageSquare className="h-4 w-4 mr-1" />
+                      Open full thread
+                    </a>
+                  </Button>
+                )}
                 <Button variant="outline" onClick={() => { setDrawerOpen(false); setDrawerReport(null) }}>
                   Cancel
                 </Button>

--- a/app/(pages)/admin/chat/page.tsx
+++ b/app/(pages)/admin/chat/page.tsx
@@ -99,7 +99,9 @@ function AdminChatInner() {
         toast.error("Failed to load conversations")
       }
     } finally {
-      if (!silent && requestId === inboxRequestIdRef.current) {
+      // Always clear when this request is latest — a silent poll can supersede a
+      // slow initial load and must not leave the spinner stuck.
+      if (requestId === inboxRequestIdRef.current) {
         setListLoading(false)
       }
     }

--- a/app/(pages)/admin/chat/page.tsx
+++ b/app/(pages)/admin/chat/page.tsx
@@ -8,6 +8,7 @@ import { useChatPolling } from "@/hooks/useChatPolling"
 import { setAdminActiveConversationId, markAdminConversationSeen } from "@/hooks/useAdminUnreadCount"
 import { Card, CardContent } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
+import { Badge } from "@/components/ui/badge"
 import { Input } from "@/components/ui/input"
 import { Loader2, RefreshCw, Send, Lock, MessageSquare } from "lucide-react"
 import { toast } from "sonner"
@@ -18,11 +19,14 @@ interface AdminConversation {
   status: string
   supportTargetUserId?: { _id: string; name?: string; email?: string }
   supportAdminId?: { _id: string; name?: string; email?: string }
+  customerId?: { _id: string; name?: string; email?: string }
+  professionalId?: { _id: string; name?: string; email?: string }
 }
 
 interface AdminConversationListItem {
   _id: string
   supportTargetUserId?: { _id: string; name?: string; email?: string }
+  supportAdminId?: { _id: string; name?: string; email?: string } | null
   lastMessagePreview?: string
   lastMessageAt?: string | null
   awaitingReply?: boolean
@@ -36,6 +40,8 @@ interface AdminMessage {
   createdAt: string
 }
 
+type InboxFilter = 'all' | 'mine'
+
 const BACKEND = process.env.NEXT_PUBLIC_BACKEND_URL
 
 function AdminChatInner() {
@@ -47,6 +53,7 @@ function AdminChatInner() {
   const [selectedId, setSelectedId] = useState<string>(queryConversationId)
   const conversationId = selectedId
 
+  const [inboxFilter, setInboxFilter] = useState<InboxFilter>('all')
   const [conversations, setConversations] = useState<AdminConversationListItem[]>([])
   const [listLoading, setListLoading] = useState(true)
   const [conversation, setConversation] = useState<AdminConversation | null>(null)
@@ -77,7 +84,8 @@ function AdminChatInner() {
   const loadConversations = useCallback(async (silent = false) => {
     if (!silent) setListLoading(true)
     try {
-      const res = await authFetch(`${BACKEND}/api/admin/conversations`)
+      const qs = inboxFilter === 'mine' ? '?mine=true' : ''
+      const res = await authFetch(`${BACKEND}/api/admin/conversations${qs}`)
       const json = await res.json()
       if (!res.ok || !json?.success) {
         throw new Error(json?.msg || "Failed to load conversations")
@@ -88,7 +96,7 @@ function AdminChatInner() {
     } finally {
       if (!silent) setListLoading(false)
     }
-  }, [])
+  }, [inboxFilter])
 
   const load = useCallback(async (silent = false) => {
     if (!conversationId) {
@@ -142,7 +150,7 @@ function AdminChatInner() {
   const pollConversations = useCallback(() => loadConversations(true), [loadConversations])
 
   useChatPolling(pollMessages, 6000, user?.role === 'admin' && !!conversationId, [conversationId])
-  useChatPolling(pollConversations, 15000, user?.role === 'admin', [])
+  useChatPolling(pollConversations, 15000, user?.role === 'admin', [inboxFilter])
 
   useEffect(() => {
     const container = messagesContainerRef.current
@@ -217,8 +225,11 @@ function AdminChatInner() {
 
   if (loading || !user || user.role !== 'admin') return null
 
-  const target = conversation?.supportTargetUserId
+  const isDirect = conversation?.type === 'direct'
   const isClosed = conversation?.status === "archived"
+  const target = conversation?.supportTargetUserId
+  const customer = conversation?.customerId
+  const professional = conversation?.professionalId
 
   return (
     <div className="min-h-screen bg-gray-50 p-4">
@@ -237,7 +248,29 @@ function AdminChatInner() {
         <div className="grid grid-cols-1 md:grid-cols-[320px_1fr] gap-4">
           <Card className="h-[70vh] overflow-hidden">
             <CardContent className="p-0 h-full overflow-y-auto">
-              <div className="border-b px-4 py-3 text-sm font-semibold text-gray-700">Inbox</div>
+              <div className="border-b px-4 py-3 space-y-2">
+                <div className="text-sm font-semibold text-gray-700">Inbox</div>
+                <div className="flex gap-1">
+                  <Button
+                    type="button"
+                    size="sm"
+                    variant={inboxFilter === 'all' ? 'default' : 'outline'}
+                    className="h-7 px-2.5 text-xs"
+                    onClick={() => setInboxFilter('all')}
+                  >
+                    All
+                  </Button>
+                  <Button
+                    type="button"
+                    size="sm"
+                    variant={inboxFilter === 'mine' ? 'default' : 'outline'}
+                    className="h-7 px-2.5 text-xs"
+                    onClick={() => setInboxFilter('mine')}
+                  >
+                    Mine
+                  </Button>
+                </div>
+              </div>
               {listLoading ? (
                 <div className="flex justify-center py-8"><Loader2 className="h-5 w-5 animate-spin text-gray-400" /></div>
               ) : conversations.length === 0 ? (
@@ -246,6 +279,7 @@ function AdminChatInner() {
                 <ul className="divide-y">
                   {conversations.map((c) => {
                     const u = c.supportTargetUserId
+                    const assignee = c.supportAdminId
                     const active = c._id === conversationId
                     return (
                       <li key={c._id}>
@@ -269,6 +303,11 @@ function AdminChatInner() {
                               )}
                             </div>
                           </div>
+                          {assignee?.name || assignee?.email ? (
+                            <p className="mt-0.5 text-[11px] text-gray-500 truncate">
+                              Assigned: {assignee.name || assignee.email}
+                            </p>
+                          ) : null}
                           <p className={`mt-0.5 text-xs truncate ${c.awaitingReply ? 'text-gray-700 font-medium' : 'text-gray-400'}`}>
                             {c.lastMessagePreview || "No messages yet."}
                           </p>
@@ -282,11 +321,24 @@ function AdminChatInner() {
           </Card>
 
           <div className="space-y-4">
-            {target && (
+            {isDirect ? (
+              <div className="flex flex-wrap items-center gap-2">
+                <p className="text-sm text-gray-500">
+                  Customer: {customer?.name || customer?.email || "—"}
+                  {customer?.email && customer?.name ? ` (${customer.email})` : ""}
+                  {" · "}
+                  Professional: {professional?.name || professional?.email || "—"}
+                  {professional?.email && professional?.name ? ` (${professional.email})` : ""}
+                </p>
+                <Badge variant="secondary" className="text-xs">
+                  Read-only — customer↔professional thread
+                </Badge>
+              </div>
+            ) : target ? (
               <p className="text-sm text-gray-500">
                 With {target.name || target.email || "user"} {target.email ? `(${target.email})` : ""}
               </p>
-            )}
+            ) : null}
 
             {loadError && (
               <div className="rounded-md border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
@@ -300,7 +352,7 @@ function AdminChatInner() {
               <Card>
                 <CardContent className="p-0">
                   <div className="flex items-center justify-end border-b p-2">
-                    {!isClosed && conversation && (
+                    {!isDirect && !isClosed && conversation && (
                       <Button
                         variant="destructive"
                         size="sm"
@@ -335,7 +387,11 @@ function AdminChatInner() {
                     )}
                   </div>
                   <div className="border-t p-3">
-                    {isClosed ? (
+                    {isDirect ? (
+                      <p className="text-center text-sm text-gray-400 flex items-center justify-center gap-1">
+                        <Lock className="h-4 w-4" /> Read-only — you cannot reply to customer↔professional threads.
+                      </p>
+                    ) : isClosed ? (
                       <p className="text-center text-sm text-gray-400 flex items-center justify-center gap-1">
                         <Lock className="h-4 w-4" /> This support chat is closed.
                       </p>

--- a/app/(pages)/admin/chat/page.tsx
+++ b/app/(pages)/admin/chat/page.tsx
@@ -66,6 +66,7 @@ function AdminChatInner() {
   const messagesContainerRef = useRef<HTMLDivElement | null>(null)
   const lastMessageIdRef = useRef<string | null>(null)
   const selectedIdRef = useRef<string>(selectedId)
+  const inboxRequestIdRef = useRef(0)
 
   useEffect(() => {
     selectedIdRef.current = selectedId
@@ -82,19 +83,25 @@ function AdminChatInner() {
   }, [queryConversationId])
 
   const loadConversations = useCallback(async (silent = false) => {
+    const requestId = ++inboxRequestIdRef.current
     if (!silent) setListLoading(true)
     try {
       const qs = inboxFilter === 'mine' ? '?mine=true' : ''
       const res = await authFetch(`${BACKEND}/api/admin/conversations${qs}`)
       const json = await res.json()
+      if (requestId !== inboxRequestIdRef.current) return
       if (!res.ok || !json?.success) {
         throw new Error(json?.msg || "Failed to load conversations")
       }
       setConversations(Array.isArray(json.data?.items) ? json.data.items : [])
     } catch {
-      if (!silent) toast.error("Failed to load conversations")
+      if (!silent && requestId === inboxRequestIdRef.current) {
+        toast.error("Failed to load conversations")
+      }
     } finally {
-      if (!silent) setListLoading(false)
+      if (!silent && requestId === inboxRequestIdRef.current) {
+        setListLoading(false)
+      }
     }
   }, [inboxFilter])
 

--- a/app/(pages)/admin/chat/page.tsx
+++ b/app/(pages)/admin/chat/page.tsx
@@ -180,6 +180,10 @@ function AdminChatInner() {
   const send = async () => {
     const trimmed = text.trim()
     if (!trimmed || !conversationId) return
+    if (!conversation || conversation.type === 'direct' || conversation.status === 'archived') {
+      toast.error('Cannot reply to this conversation')
+      return
+    }
     setSending(true)
     try {
       const res = await authFetch(`${BACKEND}/api/admin/conversations/${conversationId}/reply`, {
@@ -387,7 +391,9 @@ function AdminChatInner() {
                     )}
                   </div>
                   <div className="border-t p-3">
-                    {isDirect ? (
+                    {!conversation ? (
+                      <p className="text-center text-sm text-gray-400">Loading conversation…</p>
+                    ) : isDirect ? (
                       <p className="text-center text-sm text-gray-400 flex items-center justify-center gap-1">
                         <Lock className="h-4 w-4" /> Read-only — you cannot reply to customer↔professional threads.
                       </p>

--- a/app/(pages)/admin/kpi/page.tsx
+++ b/app/(pages)/admin/kpi/page.tsx
@@ -289,7 +289,7 @@ export default function AdminKpiDashboard() {
   })
   const columnsHydrated = useRef(false)
   const [loading, setLoading] = useState(true)
-  const [responseLoading, setResponseLoading] = useState(false)
+  const [responseLoading, setResponseLoading] = useState(true)
   const [sendingReport, setSendingReport] = useState(false)
   const [showEmails, setShowEmails] = useState(false)
   const requestIdRef = useRef(0)
@@ -354,7 +354,8 @@ export default function AdminKpiDashboard() {
     setCustomers([])
     setResponseRows([])
     setLoading(true)
-    setResponseLoading(false)
+    // Keep response tab in loading until its deferred fetch finishes (not while primary is pending).
+    setResponseLoading(true)
     try {
       const [sumRes, regRes, svcRes, subRes, proRes, custRes] = await Promise.all([
         authFetch(`${BACKEND}/api/admin/kpi/summary?${rangeQs}`),
@@ -392,7 +393,6 @@ export default function AdminKpiDashboard() {
     }
 
     // Load pro-response independently so a stall/failure cannot hold primary loading.
-    setResponseLoading(true)
     try {
       const respRes = await authFetch(`${BACKEND}/api/admin/kpi/professional-response?${rangeQs}&limit=50`)
       if (requestId !== requestIdRef.current) return

--- a/app/(pages)/admin/kpi/page.tsx
+++ b/app/(pages)/admin/kpi/page.tsx
@@ -354,27 +354,25 @@ export default function AdminKpiDashboard() {
     setResponseRows([])
     setLoading(true)
     try {
-      const [sumRes, regRes, svcRes, subRes, proRes, custRes, respRes] = await Promise.all([
+      const [sumRes, regRes, svcRes, subRes, proRes, custRes] = await Promise.all([
         authFetch(`${BACKEND}/api/admin/kpi/summary?${rangeQs}`),
         authFetch(`${BACKEND}/api/admin/kpi/by-region?${rangeQs}`),
         authFetch(`${BACKEND}/api/admin/kpi/by-service?${rangeQs}`),
         authFetch(`${BACKEND}/api/admin/kpi/by-subproject?${rangeQs}`),
         authFetch(`${BACKEND}/api/admin/kpi/by-professional?${rangeQs}`),
         authFetch(`${BACKEND}/api/admin/kpi/by-customer?${rangeQs}`),
-        authFetch(`${BACKEND}/api/admin/kpi/professional-response?${rangeQs}&limit=50`),
       ])
       if (requestId !== requestIdRef.current) return
       if (!sumRes.ok) {
         toast.error('Failed to load KPI summary')
       }
-      const [sumJson, regJson, svcJson, subJson, proJson, custJson, respJson] = await Promise.all([
+      const [sumJson, regJson, svcJson, subJson, proJson, custJson] = await Promise.all([
         sumRes.ok ? sumRes.json() : Promise.resolve({ data: null }),
         regRes.ok ? regRes.json() : Promise.resolve({ data: { rows: [] } }),
         svcRes.ok ? svcRes.json() : Promise.resolve({ data: { serviceBookings: [] } }),
         subRes.ok ? subRes.json() : Promise.resolve({ data: { rows: [] } }),
         proRes.ok ? proRes.json() : Promise.resolve({ data: { rows: [] } }),
         custRes.ok ? custRes.json() : Promise.resolve({ data: { rows: [] } }),
-        respRes.ok ? respRes.json() : Promise.resolve({ data: { rows: [] } }),
       ])
       if (requestId !== requestIdRef.current) return
       setSummary(sumJson.data || null)
@@ -383,7 +381,23 @@ export default function AdminKpiDashboard() {
       setSubprojects(subJson.data?.rows || [])
       setProfessionals(proJson.data?.rows || [])
       setCustomers(custJson.data?.rows || [])
-      setResponseRows(respJson.data?.rows || [])
+
+      // Isolate pro-response so a failure cannot blank the rest of the dashboard.
+      try {
+        const respRes = await authFetch(`${BACKEND}/api/admin/kpi/professional-response?${rangeQs}&limit=50`)
+        if (requestId !== requestIdRef.current) return
+        const respJson = respRes.ok ? await respRes.json() : { data: { rows: [] } }
+        if (requestId !== requestIdRef.current) return
+        setResponseRows(respJson.data?.rows || [])
+        if (!respRes.ok) {
+          toast.error('Failed to load pro response (top 50)')
+        }
+      } catch (respErr) {
+        if (requestId !== requestIdRef.current) return
+        console.error(respErr)
+        setResponseRows([])
+        toast.error('Failed to load pro response (top 50)')
+      }
     } catch (err) {
       if (requestId !== requestIdRef.current) return
       console.error(err)
@@ -851,7 +865,7 @@ export default function AdminKpiDashboard() {
             <TabsTrigger value="subproject">By Subproject</TabsTrigger>
             <TabsTrigger value="professional">By Professional</TabsTrigger>
             <TabsTrigger value="customer">By Customer</TabsTrigger>
-            <TabsTrigger value="response">Pro response</TabsTrigger>
+            <TabsTrigger value="response">Pro response (top 50)</TabsTrigger>
           </TabsList>
 
           {(['city', 'service', 'subproject', 'professional', 'customer', 'response'] as TabKey[]).map((tab) => {
@@ -871,7 +885,7 @@ export default function AdminKpiDashboard() {
             const tabTitle = tab === 'city'
               ? 'By Region (City)'
               : tab === 'response'
-                ? 'Pro response'
+                ? 'Pro response (top 50)'
                 : `By ${tab.charAt(0).toUpperCase() + tab.slice(1)}`
             return (
             <TabsContent value={tab} key={tab}>

--- a/app/(pages)/admin/kpi/page.tsx
+++ b/app/(pages)/admin/kpi/page.tsx
@@ -289,6 +289,7 @@ export default function AdminKpiDashboard() {
   })
   const columnsHydrated = useRef(false)
   const [loading, setLoading] = useState(true)
+  const [responseLoading, setResponseLoading] = useState(false)
   const [sendingReport, setSendingReport] = useState(false)
   const [showEmails, setShowEmails] = useState(false)
   const requestIdRef = useRef(0)
@@ -353,6 +354,7 @@ export default function AdminKpiDashboard() {
     setCustomers([])
     setResponseRows([])
     setLoading(true)
+    setResponseLoading(false)
     try {
       const [sumRes, regRes, svcRes, subRes, proRes, custRes] = await Promise.all([
         authFetch(`${BACKEND}/api/admin/kpi/summary?${rangeQs}`),
@@ -381,29 +383,32 @@ export default function AdminKpiDashboard() {
       setSubprojects(subJson.data?.rows || [])
       setProfessionals(proJson.data?.rows || [])
       setCustomers(custJson.data?.rows || [])
-
-      // Isolate pro-response so a failure cannot blank the rest of the dashboard.
-      try {
-        const respRes = await authFetch(`${BACKEND}/api/admin/kpi/professional-response?${rangeQs}&limit=50`)
-        if (requestId !== requestIdRef.current) return
-        const respJson = respRes.ok ? await respRes.json() : { data: { rows: [] } }
-        if (requestId !== requestIdRef.current) return
-        setResponseRows(respJson.data?.rows || [])
-        if (!respRes.ok) {
-          toast.error('Failed to load pro response (top 50)')
-        }
-      } catch (respErr) {
-        if (requestId !== requestIdRef.current) return
-        console.error(respErr)
-        setResponseRows([])
-        toast.error('Failed to load pro response (top 50)')
-      }
     } catch (err) {
       if (requestId !== requestIdRef.current) return
       console.error(err)
       toast.error('Failed to load KPI data')
     } finally {
       if (requestId === requestIdRef.current) setLoading(false)
+    }
+
+    // Load pro-response independently so a stall/failure cannot hold primary loading.
+    setResponseLoading(true)
+    try {
+      const respRes = await authFetch(`${BACKEND}/api/admin/kpi/professional-response?${rangeQs}&limit=50`)
+      if (requestId !== requestIdRef.current) return
+      const respJson = respRes.ok ? await respRes.json() : { data: { rows: [] } }
+      if (requestId !== requestIdRef.current) return
+      setResponseRows(respJson.data?.rows || [])
+      if (!respRes.ok) {
+        toast.error('Failed to load pro response (top 50)')
+      }
+    } catch (respErr) {
+      if (requestId !== requestIdRef.current) return
+      console.error(respErr)
+      setResponseRows([])
+      toast.error('Failed to load pro response (top 50)')
+    } finally {
+      if (requestId === requestIdRef.current) setResponseLoading(false)
     }
   }, [])
 
@@ -962,7 +967,7 @@ export default function AdminKpiDashboard() {
                   <SortableTable
                     columns={columns}
                     sortedRows={sorted}
-                    loading={loading}
+                    loading={tab === 'response' ? responseLoading : loading}
                     sortKey={sort.key}
                     sortDir={sort.dir}
                     onToggleSort={(k) => toggleSortForTab(tab, k)}

--- a/app/(pages)/admin/kpi/page.tsx
+++ b/app/(pages)/admin/kpi/page.tsx
@@ -26,9 +26,9 @@ const LEGACY_KPI_COLUMNS_STORAGE_KEY = 'fixera-kpi-columns-v1'
 
 type Preset = 'month' | 'quarter' | 'year' | 'last30' | 'custom'
 type SortDir = 'asc' | 'desc'
-type TabKey = 'city' | 'service' | 'subproject' | 'professional' | 'customer'
+type TabKey = 'city' | 'service' | 'subproject' | 'professional' | 'customer' | 'response'
 
-const TAB_KEYS: TabKey[] = ['city', 'service', 'subproject', 'professional', 'customer']
+const TAB_KEYS: TabKey[] = ['city', 'service', 'subproject', 'professional', 'customer', 'response']
 
 interface Summary {
   signUps: number
@@ -229,6 +229,7 @@ const TAB_SECTION_MAP: Record<TabKey, string> = {
   subproject: 'subproject',
   professional: 'professional',
   customer: 'customer',
+  response: 'response',
 }
 
 const TAB_LABEL_KEY: Record<TabKey, string> = {
@@ -237,6 +238,7 @@ const TAB_LABEL_KEY: Record<TabKey, string> = {
   subproject: 'subprojectName',
   professional: 'name',
   customer: 'name',
+  response: 'name',
 }
 
 const TAB_ROWKEY_FIELDS: Record<TabKey, string[]> = {
@@ -245,6 +247,7 @@ const TAB_ROWKEY_FIELDS: Record<TabKey, string[]> = {
   subproject: ['projectTitle', 'subprojectName'],
   professional: ['professionalId', 'email', 'name'],
   customer: ['customerId', 'email', 'name'],
+  response: ['professionalId', 'email', 'name'],
 }
 
 const makeRowKey = (tab: TabKey, row: Row) => TAB_ROWKEY_FIELDS[tab].map((f) => String(row[f] ?? '')).join('|')
@@ -268,6 +271,7 @@ export default function AdminKpiDashboard() {
   const [subprojects, setSubprojects] = useState<Row[]>([])
   const [professionals, setProfessionals] = useState<Row[]>([])
   const [customers, setCustomers] = useState<Row[]>([])
+  const [responseRows, setResponseRows] = useState<Row[]>([])
   const [activeTab, setActiveTab] = useState<TabKey>('city')
   const [sortByTab, setSortByTab] = useState<Record<TabKey, { key: string; dir: SortDir }>>({
     city: { key: 'platformRevenue', dir: 'desc' },
@@ -275,12 +279,13 @@ export default function AdminKpiDashboard() {
     subproject: { key: 'platformRevenue', dir: 'desc' },
     professional: { key: 'platformRevenue', dir: 'desc' },
     customer: { key: 'platformRevenue', dir: 'desc' },
+    response: { key: 'avgHours', dir: 'asc' },
   })
   const [selectedByTab, setSelectedByTab] = useState<Record<TabKey, string | null>>({
-    city: null, service: null, subproject: null, professional: null, customer: null,
+    city: null, service: null, subproject: null, professional: null, customer: null, response: null,
   })
   const [visibleColsByTab, setVisibleColsByTab] = useState<Record<TabKey, string[]>>({
-    city: [], service: [], subproject: [], professional: [], customer: [],
+    city: [], service: [], subproject: [], professional: [], customer: [], response: [],
   })
   const columnsHydrated = useRef(false)
   const [loading, setLoading] = useState(true)
@@ -346,27 +351,30 @@ export default function AdminKpiDashboard() {
     setSubprojects([])
     setProfessionals([])
     setCustomers([])
+    setResponseRows([])
     setLoading(true)
     try {
-      const [sumRes, regRes, svcRes, subRes, proRes, custRes] = await Promise.all([
+      const [sumRes, regRes, svcRes, subRes, proRes, custRes, respRes] = await Promise.all([
         authFetch(`${BACKEND}/api/admin/kpi/summary?${rangeQs}`),
         authFetch(`${BACKEND}/api/admin/kpi/by-region?${rangeQs}`),
         authFetch(`${BACKEND}/api/admin/kpi/by-service?${rangeQs}`),
         authFetch(`${BACKEND}/api/admin/kpi/by-subproject?${rangeQs}`),
         authFetch(`${BACKEND}/api/admin/kpi/by-professional?${rangeQs}`),
         authFetch(`${BACKEND}/api/admin/kpi/by-customer?${rangeQs}`),
+        authFetch(`${BACKEND}/api/admin/kpi/professional-response?${rangeQs}&limit=50`),
       ])
       if (requestId !== requestIdRef.current) return
       if (!sumRes.ok) {
         toast.error('Failed to load KPI summary')
       }
-      const [sumJson, regJson, svcJson, subJson, proJson, custJson] = await Promise.all([
+      const [sumJson, regJson, svcJson, subJson, proJson, custJson, respJson] = await Promise.all([
         sumRes.ok ? sumRes.json() : Promise.resolve({ data: null }),
         regRes.ok ? regRes.json() : Promise.resolve({ data: { rows: [] } }),
         svcRes.ok ? svcRes.json() : Promise.resolve({ data: { serviceBookings: [] } }),
         subRes.ok ? subRes.json() : Promise.resolve({ data: { rows: [] } }),
         proRes.ok ? proRes.json() : Promise.resolve({ data: { rows: [] } }),
         custRes.ok ? custRes.json() : Promise.resolve({ data: { rows: [] } }),
+        respRes.ok ? respRes.json() : Promise.resolve({ data: { rows: [] } }),
       ])
       if (requestId !== requestIdRef.current) return
       setSummary(sumJson.data || null)
@@ -375,6 +383,7 @@ export default function AdminKpiDashboard() {
       setSubprojects(subJson.data?.rows || [])
       setProfessionals(proJson.data?.rows || [])
       setCustomers(custJson.data?.rows || [])
+      setResponseRows(respJson.data?.rows || [])
     } catch (err) {
       if (requestId !== requestIdRef.current) return
       console.error(err)
@@ -442,7 +451,8 @@ export default function AdminKpiDashboard() {
     subproject: subprojects,
     professional: professionals,
     customer: customers,
-  }), [regions, serviceBookings, subprojects, professionals, customers])
+    response: responseRows,
+  }), [regions, serviceBookings, subprojects, professionals, customers, responseRows])
 
   const activeSorted = useMemo(
     () => sortRows(tabRowsMap[activeTab], sortByTab[activeTab].key, sortByTab[activeTab].dir),
@@ -484,10 +494,12 @@ export default function AdminKpiDashboard() {
       ],
       service: [
         { key: 'serviceType', label: 'Service' },
+        { key: 'views', label: 'Views', numeric: true },
         { key: 'totalRfqs', label: 'RFQs', numeric: true },
         { key: 'quotedCount', label: 'Quotes', numeric: true },
         { key: 'bookingsCount', label: 'Bookings', numeric: true },
         { key: 'completedCount', label: 'Completed', numeric: true },
+        { key: 'bookingRate', label: 'Book rate %', numeric: true, format: fmtPct },
         { key: 'grossRevenue', label: 'Gross €', numeric: true, format: fmtMoney },
         { key: 'platformRevenue', label: 'Platform €', numeric: true, format: fmtMoney },
         { key: 'refundAmount', label: 'Refund €', numeric: true, format: fmtMoney },
@@ -604,6 +616,15 @@ export default function AdminKpiDashboard() {
         { key: 'completionOverdueRate', label: 'Compl overdue %', numeric: true, format: fmtPct },
         { key: 'avgCompletionOverdueDays', label: 'Avg compl overdue (d)', numeric: true },
       ],
+      response: [
+        { key: 'name', label: 'Name' },
+        { key: 'email', label: 'Email', format: emailFormat },
+        { key: 'city', label: 'City' },
+        { key: 'quotesSent', label: 'Quotes sent', numeric: true },
+        { key: 'avgHours', label: 'Avg hours', numeric: true },
+        { key: 'minHours', label: 'Min hours', numeric: true },
+        { key: 'maxHours', label: 'Max hours', numeric: true },
+      ],
     }
   }, [showEmails])
 
@@ -647,7 +668,11 @@ export default function AdminKpiDashboard() {
         const vis = visibleColsByTab[tab]
         if (!vis || vis.length === 0) return
         if (!vis.includes(prev[tab].key)) {
-          const fallback = vis.includes('platformRevenue') ? 'platformRevenue' : vis[vis.length - 1]
+          const fallback = vis.includes('platformRevenue')
+            ? 'platformRevenue'
+            : vis.includes('avgHours')
+              ? 'avgHours'
+              : vis[vis.length - 1]
           next[tab] = { key: fallback, dir: 'desc' }
           changed = true
         }
@@ -684,7 +709,7 @@ export default function AdminKpiDashboard() {
     const columns = columnsByTab[activeTab]
     const sort = sortByTab[activeTab]
     const sortColumn = columns.find((c) => c.key === sort.key)
-    const chartKey = sortColumn?.numeric ? sort.key : 'platformRevenue'
+    const chartKey = sortColumn?.numeric ? sort.key : (activeTab === 'response' ? 'avgHours' : 'platformRevenue')
     const labelKey = TAB_LABEL_KEY[activeTab]
     return activeSorted.slice(0, 12).map((r) => ({
       name: String(r[labelKey] ?? '—'),
@@ -820,15 +845,16 @@ export default function AdminKpiDashboard() {
         </div>
 
         <Tabs value={activeTab} onValueChange={(v) => setActiveTab(v as TabKey)} className="w-full">
-          <TabsList className="grid w-full grid-cols-2 md:grid-cols-5 gap-1">
+          <TabsList className="grid w-full grid-cols-2 md:grid-cols-3 lg:grid-cols-6 gap-1 h-auto">
             <TabsTrigger value="city">By City</TabsTrigger>
             <TabsTrigger value="service">By Service</TabsTrigger>
             <TabsTrigger value="subproject">By Subproject</TabsTrigger>
             <TabsTrigger value="professional">By Professional</TabsTrigger>
             <TabsTrigger value="customer">By Customer</TabsTrigger>
+            <TabsTrigger value="response">Pro response</TabsTrigger>
           </TabsList>
 
-          {(['city', 'service', 'subproject', 'professional', 'customer'] as TabKey[]).map((tab) => {
+          {(['city', 'service', 'subproject', 'professional', 'customer', 'response'] as TabKey[]).map((tab) => {
             const allCols: KpiColumn[] = columnsByTab[tab]
             const columns: KpiColumn[] = getVisibleColumns(tab)
             const identityKey = allCols[0]?.key
@@ -837,16 +863,21 @@ export default function AdminKpiDashboard() {
             const sorted = isActive ? activeSorted : []
             const selectedKey = selectedByTab[tab]
             const sortColumn = allCols.find((c) => c.key === sort.key)
-            const chartKey = sortColumn?.numeric ? sort.key : 'platformRevenue'
+            const chartKey = sortColumn?.numeric ? sort.key : (tab === 'response' ? 'avgHours' : 'platformRevenue')
             const chartColumn = allCols.find((c) => c.key === chartKey)
-            const chartLabel = chartColumn?.label || 'Platform €'
+            const chartLabel = chartColumn?.label || (tab === 'response' ? 'Avg hours' : 'Platform €')
             const chartFmt = chartColumn?.format
             const chartData = isActive ? activeChartData : []
+            const tabTitle = tab === 'city'
+              ? 'By Region (City)'
+              : tab === 'response'
+                ? 'Pro response'
+                : `By ${tab.charAt(0).toUpperCase() + tab.slice(1)}`
             return (
             <TabsContent value={tab} key={tab}>
               <Card>
                 <CardHeader className="flex flex-row items-center justify-between flex-wrap gap-2">
-                  <CardTitle className="text-base capitalize">{tab === 'city' ? 'By Region (City)' : `By ${tab.charAt(0).toUpperCase() + tab.slice(1)}`}</CardTitle>
+                  <CardTitle className="text-base capitalize">{tabTitle}</CardTitle>
                   <div className="flex gap-2">
                     <DropdownMenu>
                       <DropdownMenuTrigger asChild>

--- a/app/(pages)/dashboard/page.tsx
+++ b/app/(pages)/dashboard/page.tsx
@@ -4,7 +4,7 @@ import { useAuth } from "@/contexts/AuthContext"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
 import { Badge } from "@/components/ui/badge"
-import { User, Mail, Phone, Shield, Calendar, Crown, Settings, TrendingUp, Users, Award, CheckCircle, XCircle, Clock, AlertTriangle, Plus, Briefcase, Package, CreditCard, FileText, Star, Gift, Play, Loader2, Info, MessageSquareWarning, EyeOff, Heart, LifeBuoy, Ticket, BarChart3, Ban, AlertOctagon, Link2 } from "lucide-react"
+import { User, Mail, Phone, Shield, Calendar, Crown, Settings, TrendingUp, Users, Award, CheckCircle, XCircle, Clock, AlertTriangle, Plus, Briefcase, Package, CreditCard, FileText, Star, Gift, Play, Loader2, Info, MessageSquareWarning, EyeOff, Heart, LifeBuoy, Ticket, BarChart3, Ban, AlertOctagon, Link2, MessageSquare } from "lucide-react"
 import { useRouter } from "next/navigation"
 import { useEffect, useMemo, useState } from "react"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
@@ -806,9 +806,9 @@ export default function DashboardPage() {
                 <CardHeader>
                   <CardTitle className="flex items-center gap-2">
                     <LifeBuoy className="h-5 w-5 text-indigo-500" />
-                    Professional Support
+                    Professional Support Tickets
                   </CardTitle>
-                  <CardDescription>Review tickets and meeting requests from professionals</CardDescription>
+                  <CardDescription>Review support tickets and meeting requests from professionals (not live chat)</CardDescription>
                 </CardHeader>
                 <CardContent>
                   <Button
@@ -816,7 +816,26 @@ export default function DashboardPage() {
                     className="w-full bg-gradient-to-r from-indigo-500 to-blue-500 hover:from-indigo-600 hover:to-blue-600"
                   >
                     <LifeBuoy className="h-4 w-4 mr-2" />
-                    Open Support Inbox
+                    Open Support Tickets
+                  </Button>
+                </CardContent>
+              </Card>
+
+              <Card className="border-sky-100 bg-gradient-to-br from-white via-sky-50 to-indigo-100 shadow-md transition-all duration-200 hover:-translate-y-1 hover:shadow-xl">
+                <CardHeader>
+                  <CardTitle className="flex items-center gap-2">
+                    <MessageSquare className="h-5 w-5 text-sky-600" />
+                    Support Chat
+                  </CardTitle>
+                  <CardDescription>Shared inbox for platform support chats with customers and professionals</CardDescription>
+                </CardHeader>
+                <CardContent>
+                  <Button
+                    onClick={() => openAdmin('/admin/chat')}
+                    className="w-full bg-gradient-to-r from-sky-500 to-indigo-600 hover:from-sky-600 hover:to-indigo-700"
+                  >
+                    <MessageSquare className="h-4 w-4 mr-2" />
+                    Open Support Chat
                   </Button>
                 </CardContent>
               </Card>


### PR DESCRIPTION
## Summary
- Shared support chat inbox (All/Mine) with assignee labels; customer↔pro threads open read-only
- Open full thread from chat reports; view customer↔pro chat from booking detail
- KPI: service views + booking rate columns; new Pro response tab
- Audit log CSV/JSON export with dynamic filter options; dashboard Support Chat card

## Test plan
- [ ] Build passes
- [ ] `/admin/chat` All vs Mine; open a direct chat via booking/report and confirm read-only
- [ ] Chat report drawer “Open full thread” works
- [ ] KPI service tab shows Views / Book rate %; Pro response tab loads
- [ ] Audit logs export respects current filters
- [ ] Dashboard Support Chat card opens `/admin/chat`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Audit logs: Action/Target type dropdowns now load options dynamically; added CSV/JSON export for current filters with exporting state and toasts.
  * Booking details: added “View customer↔pro chat” opening the thread in a new tab.
  * Chat reports: added “Open full thread” when a conversation is available.
  * Admin chat: added “All” vs “Mine” inbox filtering; direct chats are now read-only with “Assigned:” display.
  * KPI dashboard: added “Pro response (top 50)” tab with response-specific table/chart behavior.
  * Dashboard: split support shortcuts into “Support Tickets” and “Support Chat.”
<!-- end of auto-generated comment: release notes by coderabbit.ai -->