### PR TITLE
feat(marketing): Phase C campaigns admin UI + unsubscribe

### DIFF
--- a/app/(pages)/admin/accept-invite/page.tsx
+++ b/app/(pages)/admin/accept-invite/page.tsx
@@ -111,7 +111,8 @@ function AcceptInviteContent() {
       // Acceptance already succeeded — session sync failures must not look like activation failures
       setAuthToken(json.token);
       try {
-        await checkAuth();
+        const currentUser = await checkAuth();
+        if (!currentUser) throw new Error('Session refresh failed');
         toast.success('Account activated — welcome to the team');
         router.push('/dashboard');
       } catch {

--- a/app/(pages)/admin/accept-invite/page.tsx
+++ b/app/(pages)/admin/accept-invite/page.tsx
@@ -111,7 +111,7 @@ function AcceptInviteContent() {
       // Acceptance already succeeded — session sync failures must not look like activation failures
       setAuthToken(json.token);
       try {
-        const currentUser = await checkAuth();
+        const currentUser = await checkAuth({ strict: true });
         if (!currentUser) throw new Error('Session refresh failed');
         toast.success('Account activated — welcome to the team');
         router.push('/dashboard');

--- a/app/(pages)/admin/bookings/[id]/page.tsx
+++ b/app/(pages)/admin/bookings/[id]/page.tsx
@@ -12,6 +12,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@
 import { ArrowLeft, RefreshCw, MessageSquare } from "lucide-react"
 import { toast } from "sonner"
 import { FORCEABLE_BOOKING_STATUSES } from "@/lib/constants/adminBookingStatus"
+import { useAdminAccess } from "@/hooks/useAdminAccess"
 
 interface Refund {
   amount: number
@@ -92,6 +93,9 @@ export default function AdminBookingDetailPage() {
   const router = useRouter()
   const params = useParams<{ id: string }>()
   const id = params?.id
+  const { can } = useAdminAccess()
+  const canWriteBookings = can('bookings.write')
+  const canUseSupportChat = can('chat.support')
 
   const [data, setData] = useState<BookingDetailPayload | null>(null)
   const [isLoading, setIsLoading] = useState(true)
@@ -261,35 +265,40 @@ export default function AdminBookingDetailPage() {
                   >
                     Open customer view
                   </Button>
-                  <Button
-                    size="sm"
-                    variant="outline"
-                    disabled={startingChat === 'customer' || !data.booking.customer?._id}
-                    onClick={() => handleStartSupportChat('customer')}
-                  >
-                    <MessageSquare className="h-4 w-4 mr-1" />
-                    {startingChat === 'customer' ? 'Opening…' : 'Chat customer'}
-                  </Button>
-                  <Button
-                    size="sm"
-                    variant="outline"
-                    disabled={startingChat === 'professional' || !data.booking.professional?._id}
-                    onClick={() => handleStartSupportChat('professional')}
-                  >
-                    <MessageSquare className="h-4 w-4 mr-1" />
-                    {startingChat === 'professional' ? 'Opening…' : 'Chat professional'}
-                  </Button>
-                  <Button
-                    size="sm"
-                    variant="outline"
-                    disabled={openingProChat}
-                    onClick={viewCustomerProChat}
-                  >
-                    <MessageSquare className="h-4 w-4 mr-1" />
-                    {openingProChat ? 'Opening…' : 'View customer↔pro chat'}
-                  </Button>
+                  {canUseSupportChat && (
+                    <>
+                      <Button
+                        size="sm"
+                        variant="outline"
+                        disabled={startingChat === 'customer' || !data.booking.customer?._id}
+                        onClick={() => handleStartSupportChat('customer')}
+                      >
+                        <MessageSquare className="h-4 w-4 mr-1" />
+                        {startingChat === 'customer' ? 'Opening…' : 'Chat customer'}
+                      </Button>
+                      <Button
+                        size="sm"
+                        variant="outline"
+                        disabled={startingChat === 'professional' || !data.booking.professional?._id}
+                        onClick={() => handleStartSupportChat('professional')}
+                      >
+                        <MessageSquare className="h-4 w-4 mr-1" />
+                        {startingChat === 'professional' ? 'Opening…' : 'Chat professional'}
+                      </Button>
+                      <Button
+                        size="sm"
+                        variant="outline"
+                        disabled={openingProChat}
+                        onClick={viewCustomerProChat}
+                      >
+                        <MessageSquare className="h-4 w-4 mr-1" />
+                        {openingProChat ? 'Opening…' : 'View customer↔pro chat'}
+                      </Button>
+                    </>
+                  )}
                 </div>
-                <div className="flex flex-wrap items-center gap-2 pt-3 border-t mt-3">
+                {canWriteBookings && (
+                  <div className="flex flex-wrap items-center gap-2 pt-3 border-t mt-3">
                   <span className="text-xs text-gray-500">Force status:</span>
                   <Select value={forceStatusValue} onValueChange={setForceStatusValue}>
                     <SelectTrigger className="h-8 w-52 text-xs">
@@ -309,7 +318,8 @@ export default function AdminBookingDetailPage() {
                     {forcingStatus ? 'Applying…' : 'Apply'}
                   </Button>
                   <span className="text-[11px] text-gray-400">Status override only — does not trigger payments/refunds.</span>
-                </div>
+                  </div>
+                )}
               </CardContent>
             </Card>
 

--- a/app/(pages)/admin/campaigns/page.tsx
+++ b/app/(pages)/admin/campaigns/page.tsx
@@ -662,7 +662,7 @@ export default function AdminCampaignsPage() {
                   <div>Unique clicks: {totals.clicks}</div>
                   {c.scheduledAt && (
                     <div className="sm:col-span-4">
-                      Scheduled: {new Date(c.scheduledAt).toLocaleString()}
+                      Eligible after: {new Date(c.scheduledAt).toLocaleString()}
                     </div>
                   )}
                 </CardContent>
@@ -824,12 +824,15 @@ export default function AdminCampaignsPage() {
 
             <div className="grid gap-3 sm:grid-cols-2">
               <div className="space-y-2">
-                <Label>Schedule (optional)</Label>
+                <Label>Eligible after (optional)</Label>
                 <Input
                   type="datetime-local"
                   value={form.scheduledAt}
                   onChange={(e) => setForm((f) => ({ ...f, scheduledAt: e.target.value }))}
                 />
+                <p className="text-xs text-muted-foreground">
+                  Delivery is attempted during the first daily campaign run after this time (08:00 UTC).
+                </p>
               </div>
               <div className="space-y-2">
                 <Label>UTM campaign</Label>

--- a/app/(pages)/admin/campaigns/page.tsx
+++ b/app/(pages)/admin/campaigns/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import { useAuth } from "@/contexts/AuthContext";
 import { authFetch } from "@/lib/utils";
@@ -171,6 +171,7 @@ export default function AdminCampaignsPage() {
   const [audienceLoading, setAudienceLoading] = useState(false);
   const [syncing, setSyncing] = useState(false);
   const [actionIds, setActionIds] = useState<Set<string>>(() => new Set());
+  const latestLoadId = useRef(0);
 
   useEffect(() => {
     if (authLoading) return;
@@ -198,16 +199,23 @@ export default function AdminCampaignsPage() {
   };
 
   const load = useCallback(async () => {
+    const loadId = ++latestLoadId.current;
     setLoading(true);
     try {
       const res = await authFetch(`${requireApiBase()}/api/admin/marketing-campaigns?limit=50`);
       const json = await res.json();
       if (!res.ok || !json.success) throw new Error(json.msg || "Failed to load");
-      setCampaigns(json.data.campaigns || []);
+      if (loadId === latestLoadId.current) {
+        setCampaigns(json.data.campaigns || []);
+      }
     } catch (e: unknown) {
-      toast.error(errMessage(e, "Failed to load campaigns"));
+      if (loadId === latestLoadId.current) {
+        toast.error(errMessage(e, "Failed to load campaigns"));
+      }
     } finally {
-      setLoading(false);
+      if (loadId === latestLoadId.current) {
+        setLoading(false);
+      }
     }
   }, []);
 

--- a/app/(pages)/admin/campaigns/page.tsx
+++ b/app/(pages)/admin/campaigns/page.tsx
@@ -1,0 +1,758 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { useRouter } from "next/navigation";
+import { useAuth } from "@/contexts/AuthContext";
+import { authFetch } from "@/lib/utils";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Badge } from "@/components/ui/badge";
+import {
+  Plus,
+  Pencil,
+  Trash2,
+  Send,
+  RefreshCw,
+  Users,
+  Loader2,
+  Mail,
+  BarChart3,
+} from "lucide-react";
+import { toast } from "sonner";
+
+const API_BASE = process.env.NEXT_PUBLIC_BACKEND_URL || "http://localhost:4000";
+const LOCALES = ["en", "nl", "fr"] as const;
+type Locale = (typeof LOCALES)[number];
+type CampaignType = "newsletter" | "promotion" | "reengagement";
+
+interface LocaleContent {
+  subject: string;
+  htmlContent: string;
+  previewText?: string;
+  brevoTemplateId?: number;
+}
+
+interface Campaign {
+  _id: string;
+  name: string;
+  type: CampaignType;
+  status: string;
+  content: Partial<Record<Locale, LocaleContent>>;
+  audience: {
+    countries: string[];
+    interestedServices: string[];
+    locales: Locale[];
+    roles: Array<"customer" | "professional">;
+  };
+  inactiveDays?: number;
+  autoSend: boolean;
+  scheduledAt?: string | null;
+  sentAt?: string | null;
+  deliveries: Array<{
+    locale: Locale;
+    recipientCount: number;
+    brevoCampaignId?: number;
+    stats?: {
+      sent: number;
+      delivered: number;
+      uniqueViews: number;
+      uniqueClicks: number;
+      unsubscriptions: number;
+    };
+    error?: string;
+  }>;
+  lastError?: string;
+  utmCampaign?: string;
+  updatedAt: string;
+}
+
+interface FormState {
+  name: string;
+  type: CampaignType;
+  countries: string;
+  interestedServices: string;
+  locales: Locale[];
+  roles: Array<"customer" | "professional">;
+  inactiveDays: string;
+  autoSend: boolean;
+  scheduledAt: string;
+  utmCampaign: string;
+  content: Record<Locale, LocaleContent>;
+}
+
+const emptyContent = (): LocaleContent => ({
+  subject: "",
+  htmlContent: "",
+  previewText: "",
+});
+
+const emptyForm = (): FormState => ({
+  name: "",
+  type: "newsletter",
+  countries: "",
+  interestedServices: "",
+  locales: ["en"],
+  roles: ["customer", "professional"],
+  inactiveDays: "60",
+  autoSend: false,
+  scheduledAt: "",
+  utmCampaign: "",
+  content: {
+    en: emptyContent(),
+    nl: emptyContent(),
+    fr: emptyContent(),
+  },
+});
+
+const statusColor = (status: string) => {
+  switch (status) {
+    case "sent":
+      return "bg-emerald-100 text-emerald-800";
+    case "scheduled":
+      return "bg-blue-100 text-blue-800";
+    case "failed":
+      return "bg-rose-100 text-rose-800";
+    case "sending":
+      return "bg-amber-100 text-amber-800";
+    default:
+      return "bg-slate-100 text-slate-700";
+  }
+};
+
+export default function AdminCampaignsPage() {
+  const router = useRouter();
+  const { user, loading: authLoading } = useAuth();
+  const [campaigns, setCampaigns] = useState<Campaign[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [form, setForm] = useState<FormState>(emptyForm);
+  const [saving, setSaving] = useState(false);
+  const [activeLocaleTab, setActiveLocaleTab] = useState<Locale>("en");
+  const [audienceCount, setAudienceCount] = useState<number | null>(null);
+  const [audienceLoading, setAudienceLoading] = useState(false);
+  const [syncing, setSyncing] = useState(false);
+  const [actionId, setActionId] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!authLoading && user?.role !== "admin") router.replace("/");
+  }, [authLoading, user, router]);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    try {
+      const res = await authFetch(`${API_BASE}/api/admin/marketing-campaigns?limit=50`);
+      const json = await res.json();
+      if (!res.ok || !json.success) throw new Error(json.msg || "Failed to load");
+      setCampaigns(json.data.campaigns || []);
+    } catch (e: any) {
+      toast.error(e.message || "Failed to load campaigns");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (user?.role === "admin") load();
+  }, [user, load]);
+
+  const openCreate = () => {
+    setEditingId(null);
+    setForm(emptyForm());
+    setAudienceCount(null);
+    setActiveLocaleTab("en");
+    setDialogOpen(true);
+  };
+
+  const openEdit = (c: Campaign) => {
+    setEditingId(c._id);
+    setForm({
+      name: c.name,
+      type: c.type,
+      countries: (c.audience?.countries || []).join(", "),
+      interestedServices: (c.audience?.interestedServices || []).join(", "),
+      locales: (c.audience?.locales?.length ? c.audience.locales : LOCALES.filter((l) => c.content?.[l])) as Locale[],
+      roles: c.audience?.roles?.length ? c.audience.roles : ["customer", "professional"],
+      inactiveDays: String(c.inactiveDays || 60),
+      autoSend: Boolean(c.autoSend),
+      scheduledAt: c.scheduledAt ? c.scheduledAt.slice(0, 16) : "",
+      utmCampaign: c.utmCampaign || "",
+      content: {
+        en: c.content?.en || emptyContent(),
+        nl: c.content?.nl || emptyContent(),
+        fr: c.content?.fr || emptyContent(),
+      },
+    });
+    setAudienceCount(null);
+    setActiveLocaleTab("en");
+    setDialogOpen(true);
+  };
+
+  const payload = useMemo(() => {
+    const content: Partial<Record<Locale, LocaleContent>> = {};
+    for (const locale of LOCALES) {
+      const block = form.content[locale];
+      if (block.subject.trim() && (block.htmlContent.trim() || block.brevoTemplateId)) {
+        content[locale] = {
+          subject: block.subject.trim(),
+          htmlContent: block.htmlContent,
+          previewText: block.previewText?.trim() || undefined,
+          brevoTemplateId: block.brevoTemplateId || undefined,
+        };
+      }
+    }
+    return {
+      name: form.name.trim(),
+      type: form.type,
+      audience: {
+        countries: form.countries
+          .split(",")
+          .map((c) => c.trim().toUpperCase())
+          .filter(Boolean),
+        interestedServices: form.interestedServices
+          .split(",")
+          .map((s) => s.trim())
+          .filter(Boolean),
+        locales: form.locales,
+        roles: form.roles,
+      },
+      content,
+      inactiveDays: form.type === "reengagement" ? Number(form.inactiveDays) || 60 : undefined,
+      autoSend: form.type === "reengagement" ? form.autoSend : false,
+      scheduledAt: form.scheduledAt ? new Date(form.scheduledAt).toISOString() : null,
+      utmCampaign: form.utmCampaign.trim() || undefined,
+    };
+  }, [form]);
+
+  const previewAudience = async () => {
+    setAudienceLoading(true);
+    try {
+      const res = await authFetch(`${API_BASE}/api/admin/marketing-campaigns/preview-audience`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          audience: payload.audience,
+          inactiveDays: payload.inactiveDays,
+        }),
+      });
+      const json = await res.json();
+      if (!res.ok || !json.success) throw new Error(json.msg || "Preview failed");
+      setAudienceCount(json.data.count);
+    } catch (e: any) {
+      toast.error(e.message || "Audience preview failed");
+    } finally {
+      setAudienceLoading(false);
+    }
+  };
+
+  const handleSave = async () => {
+    if (!payload.name || Object.keys(payload.content).length === 0) {
+      toast.error("Name and at least one locale with subject + HTML are required");
+      return;
+    }
+    setSaving(true);
+    try {
+      const url = editingId
+        ? `${API_BASE}/api/admin/marketing-campaigns/${editingId}`
+        : `${API_BASE}/api/admin/marketing-campaigns`;
+      const res = await authFetch(url, {
+        method: editingId ? "PATCH" : "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+      const json = await res.json();
+      if (!res.ok || !json.success) throw new Error(json.msg || "Save failed");
+      toast.success(editingId ? "Campaign updated" : "Campaign created");
+      setDialogOpen(false);
+      await load();
+    } catch (e: any) {
+      toast.error(e.message || "Save failed");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleSend = async (id: string) => {
+    if (!confirm("Send this campaign now via Brevo to the matched audience?")) return;
+    setActionId(id);
+    try {
+      const res = await authFetch(`${API_BASE}/api/admin/marketing-campaigns/${id}/send`, {
+        method: "POST",
+      });
+      const json = await res.json();
+      if (!res.ok || !json.success) throw new Error(json.msg || "Send failed");
+      toast.success("Campaign sent");
+      await load();
+    } catch (e: any) {
+      toast.error(e.message || "Send failed");
+    } finally {
+      setActionId(null);
+    }
+  };
+
+  const handleStats = async (id: string) => {
+    setActionId(id);
+    try {
+      const res = await authFetch(`${API_BASE}/api/admin/marketing-campaigns/${id}/stats`, {
+        method: "POST",
+      });
+      const json = await res.json();
+      if (!res.ok || !json.success) throw new Error(json.msg || "Refresh failed");
+      toast.success("Stats refreshed from Brevo");
+      await load();
+    } catch (e: any) {
+      toast.error(e.message || "Refresh failed");
+    } finally {
+      setActionId(null);
+    }
+  };
+
+  const handleDelete = async (id: string) => {
+    if (!confirm("Delete this campaign?")) return;
+    setActionId(id);
+    try {
+      const res = await authFetch(`${API_BASE}/api/admin/marketing-campaigns/${id}`, {
+        method: "DELETE",
+      });
+      const json = await res.json();
+      if (!res.ok || !json.success) throw new Error(json.msg || "Delete failed");
+      toast.success("Deleted");
+      await load();
+    } catch (e: any) {
+      toast.error(e.message || "Delete failed");
+    } finally {
+      setActionId(null);
+    }
+  };
+
+  const syncSubscribers = async () => {
+    setSyncing(true);
+    try {
+      const res = await authFetch(`${API_BASE}/api/admin/marketing-subscribers/sync`, {
+        method: "POST",
+      });
+      const json = await res.json();
+      if (!res.ok || !json.success) throw new Error(json.msg || "Sync failed");
+      toast.success(
+        `Synced subscribers (upserted ${json.data.upserted}, unsubscribed ${json.data.unsubscribed})`,
+      );
+    } catch (e: any) {
+      toast.error(e.message || "Sync failed");
+    } finally {
+      setSyncing(false);
+    }
+  };
+
+  if (authLoading || (user && user.role !== "admin")) {
+    return (
+      <div className="p-8">
+        <Skeleton className="h-10 w-64 mb-4" />
+        <Skeleton className="h-40 w-full" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="mx-auto max-w-6xl p-6 space-y-6">
+      <div className="flex flex-wrap items-start justify-between gap-4">
+        <div>
+          <h1 className="text-2xl font-semibold tracking-tight">Email campaigns</h1>
+          <p className="text-sm text-muted-foreground mt-1">
+            Multilingual newsletters, promotions, and re-engagement via Brevo — filtered by region
+            and interested service.
+          </p>
+        </div>
+        <div className="flex gap-2">
+          <Button variant="outline" onClick={syncSubscribers} disabled={syncing}>
+            {syncing ? <Loader2 className="h-4 w-4 animate-spin mr-2" /> : <Users className="h-4 w-4 mr-2" />}
+            Sync subscribers
+          </Button>
+          <Button onClick={openCreate}>
+            <Plus className="h-4 w-4 mr-2" />
+            New campaign
+          </Button>
+        </div>
+      </div>
+
+      {loading ? (
+        <div className="space-y-3">
+          <Skeleton className="h-28 w-full" />
+          <Skeleton className="h-28 w-full" />
+        </div>
+      ) : campaigns.length === 0 ? (
+        <Card>
+          <CardHeader>
+            <CardTitle>No campaigns yet</CardTitle>
+            <CardDescription>
+              Create a draft, sync subscribers from opted-in users, preview the audience, then send
+              through Brevo.
+            </CardDescription>
+          </CardHeader>
+        </Card>
+      ) : (
+        <div className="space-y-3">
+          {campaigns.map((c) => {
+            const totals = (c.deliveries || []).reduce(
+              (acc, d) => {
+                acc.recipients += d.recipientCount || 0;
+                acc.sent += d.stats?.sent || 0;
+                acc.opens += d.stats?.uniqueViews || 0;
+                acc.clicks += d.stats?.uniqueClicks || 0;
+                return acc;
+              },
+              { recipients: 0, sent: 0, opens: 0, clicks: 0 },
+            );
+            return (
+              <Card key={c._id}>
+                <CardHeader className="pb-3">
+                  <div className="flex flex-wrap items-start justify-between gap-3">
+                    <div>
+                      <CardTitle className="flex items-center gap-2 text-lg">
+                        <Mail className="h-4 w-4" />
+                        {c.name}
+                      </CardTitle>
+                      <CardDescription className="mt-1 flex flex-wrap gap-2 items-center">
+                        <Badge variant="outline">{c.type}</Badge>
+                        <span className={`rounded-full px-2 py-0.5 text-xs ${statusColor(c.status)}`}>
+                          {c.status}
+                        </span>
+                        {c.autoSend && <Badge variant="secondary">auto re-engagement</Badge>}
+                        {c.lastError && <span className="text-rose-600">{c.lastError}</span>}
+                      </CardDescription>
+                    </div>
+                    <div className="flex flex-wrap gap-2">
+                      {["draft", "scheduled", "failed"].includes(c.status) && (
+                        <Button size="sm" variant="outline" onClick={() => openEdit(c)}>
+                          <Pencil className="h-3.5 w-3.5 mr-1" />
+                          Edit
+                        </Button>
+                      )}
+                      {["draft", "scheduled", "failed"].includes(c.status) && (
+                        <Button
+                          size="sm"
+                          onClick={() => handleSend(c._id)}
+                          disabled={actionId === c._id}
+                        >
+                          {actionId === c._id ? (
+                            <Loader2 className="h-3.5 w-3.5 animate-spin mr-1" />
+                          ) : (
+                            <Send className="h-3.5 w-3.5 mr-1" />
+                          )}
+                          Send now
+                        </Button>
+                      )}
+                      {c.status === "sent" && (
+                        <Button
+                          size="sm"
+                          variant="outline"
+                          onClick={() => handleStats(c._id)}
+                          disabled={actionId === c._id}
+                        >
+                          <BarChart3 className="h-3.5 w-3.5 mr-1" />
+                          Refresh stats
+                        </Button>
+                      )}
+                      {c.status !== "sending" && (
+                        <Button
+                          size="sm"
+                          variant="ghost"
+                          onClick={() => handleDelete(c._id)}
+                          disabled={actionId === c._id}
+                        >
+                          <Trash2 className="h-3.5 w-3.5 text-rose-500" />
+                        </Button>
+                      )}
+                    </div>
+                  </div>
+                </CardHeader>
+                <CardContent className="text-sm text-muted-foreground grid gap-1 sm:grid-cols-4">
+                  <div>Recipients (send): {totals.recipients}</div>
+                  <div>Sent: {totals.sent}</div>
+                  <div>Unique opens: {totals.opens}</div>
+                  <div>Unique clicks: {totals.clicks}</div>
+                </CardContent>
+              </Card>
+            );
+          })}
+        </div>
+      )}
+
+      <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
+        <DialogContent className="max-w-3xl max-h-[90vh] overflow-y-auto">
+          <DialogHeader>
+            <DialogTitle>{editingId ? "Edit campaign" : "New campaign"}</DialogTitle>
+            <DialogDescription>
+              Audience is a closed set: promotions-opted-in subscribers matching region / service /
+              locale filters.
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="space-y-4 py-2">
+            <div className="grid gap-3 sm:grid-cols-2">
+              <div className="space-y-2">
+                <Label>Name</Label>
+                <Input
+                  value={form.name}
+                  onChange={(e) => setForm((f) => ({ ...f, name: e.target.value }))}
+                  placeholder="Spring promo BE"
+                />
+              </div>
+              <div className="space-y-2">
+                <Label>Type</Label>
+                <Select
+                  value={form.type}
+                  onValueChange={(v: CampaignType) => setForm((f) => ({ ...f, type: v }))}
+                >
+                  <SelectTrigger>
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="newsletter">Newsletter</SelectItem>
+                    <SelectItem value="promotion">Promotion</SelectItem>
+                    <SelectItem value="reengagement">Re-engagement</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+            </div>
+
+            <div className="grid gap-3 sm:grid-cols-2">
+              <div className="space-y-2">
+                <Label>Countries (comma ISO, empty = all)</Label>
+                <Input
+                  value={form.countries}
+                  onChange={(e) => setForm((f) => ({ ...f, countries: e.target.value }))}
+                  placeholder="BE, NL, FR"
+                />
+              </div>
+              <div className="space-y-2">
+                <Label>Interested services (comma, empty = all)</Label>
+                <Input
+                  value={form.interestedServices}
+                  onChange={(e) => setForm((f) => ({ ...f, interestedServices: e.target.value }))}
+                  placeholder="Plumbing, Painting"
+                />
+              </div>
+            </div>
+
+            <div className="flex flex-wrap gap-4">
+              {LOCALES.map((locale) => (
+                <label key={locale} className="flex items-center gap-2 text-sm">
+                  <Checkbox
+                    checked={form.locales.includes(locale)}
+                    onCheckedChange={(checked) =>
+                      setForm((f) => ({
+                        ...f,
+                        locales: checked
+                          ? Array.from(new Set([...f.locales, locale]))
+                          : f.locales.filter((l) => l !== locale),
+                      }))
+                    }
+                  />
+                  Audience locale {locale.toUpperCase()}
+                </label>
+              ))}
+            </div>
+
+            <div className="flex flex-wrap gap-4">
+              {(["customer", "professional"] as const).map((role) => (
+                <label key={role} className="flex items-center gap-2 text-sm">
+                  <Checkbox
+                    checked={form.roles.includes(role)}
+                    onCheckedChange={(checked) =>
+                      setForm((f) => ({
+                        ...f,
+                        roles: checked
+                          ? Array.from(new Set([...f.roles, role]))
+                          : f.roles.filter((r) => r !== role),
+                      }))
+                    }
+                  />
+                  {role}
+                </label>
+              ))}
+            </div>
+
+            {form.type === "reengagement" && (
+              <div className="grid gap-3 sm:grid-cols-2">
+                <div className="space-y-2">
+                  <Label>Inactive days</Label>
+                  <Input
+                    type="number"
+                    min={1}
+                    value={form.inactiveDays}
+                    onChange={(e) => setForm((f) => ({ ...f, inactiveDays: e.target.value }))}
+                  />
+                </div>
+                <label className="flex items-center gap-2 text-sm mt-7">
+                  <Checkbox
+                    checked={form.autoSend}
+                    onCheckedChange={(checked) =>
+                      setForm((f) => ({ ...f, autoSend: Boolean(checked) }))
+                    }
+                  />
+                  Auto-send via daily cron
+                </label>
+              </div>
+            )}
+
+            <div className="grid gap-3 sm:grid-cols-2">
+              <div className="space-y-2">
+                <Label>Schedule (optional)</Label>
+                <Input
+                  type="datetime-local"
+                  value={form.scheduledAt}
+                  onChange={(e) => setForm((f) => ({ ...f, scheduledAt: e.target.value }))}
+                />
+              </div>
+              <div className="space-y-2">
+                <Label>UTM campaign</Label>
+                <Input
+                  value={form.utmCampaign}
+                  onChange={(e) => setForm((f) => ({ ...f, utmCampaign: e.target.value }))}
+                  placeholder="spring_2026"
+                />
+              </div>
+            </div>
+
+            <div className="flex gap-2 border-b">
+              {LOCALES.map((locale) => (
+                <button
+                  key={locale}
+                  type="button"
+                  className={`px-3 py-2 text-sm ${
+                    activeLocaleTab === locale
+                      ? "border-b-2 border-foreground font-medium"
+                      : "text-muted-foreground"
+                  }`}
+                  onClick={() => setActiveLocaleTab(locale)}
+                >
+                  {locale.toUpperCase()}
+                  {form.content[locale].subject ? " ✓" : ""}
+                </button>
+              ))}
+            </div>
+
+            <div className="space-y-3">
+              <div className="space-y-2">
+                <Label>Subject ({activeLocaleTab})</Label>
+                <Input
+                  value={form.content[activeLocaleTab].subject}
+                  onChange={(e) =>
+                    setForm((f) => ({
+                      ...f,
+                      content: {
+                        ...f.content,
+                        [activeLocaleTab]: {
+                          ...f.content[activeLocaleTab],
+                          subject: e.target.value,
+                        },
+                      },
+                    }))
+                  }
+                />
+              </div>
+              <div className="space-y-2">
+                <Label>Preview text</Label>
+                <Input
+                  value={form.content[activeLocaleTab].previewText || ""}
+                  onChange={(e) =>
+                    setForm((f) => ({
+                      ...f,
+                      content: {
+                        ...f.content,
+                        [activeLocaleTab]: {
+                          ...f.content[activeLocaleTab],
+                          previewText: e.target.value,
+                        },
+                      },
+                    }))
+                  }
+                />
+              </div>
+              <div className="space-y-2">
+                <Label>HTML body (or leave minimal if using Brevo template id)</Label>
+                <Textarea
+                  className="min-h-[160px] font-mono text-xs"
+                  value={form.content[activeLocaleTab].htmlContent}
+                  onChange={(e) =>
+                    setForm((f) => ({
+                      ...f,
+                      content: {
+                        ...f.content,
+                        [activeLocaleTab]: {
+                          ...f.content[activeLocaleTab],
+                          htmlContent: e.target.value,
+                        },
+                      },
+                    }))
+                  }
+                  placeholder="<h1>Hello</h1><p>...</p>"
+                />
+              </div>
+              <div className="space-y-2">
+                <Label>Brevo template id (optional)</Label>
+                <Input
+                  type="number"
+                  value={form.content[activeLocaleTab].brevoTemplateId ?? ""}
+                  onChange={(e) =>
+                    setForm((f) => ({
+                      ...f,
+                      content: {
+                        ...f.content,
+                        [activeLocaleTab]: {
+                          ...f.content[activeLocaleTab],
+                          brevoTemplateId: e.target.value
+                            ? Number(e.target.value)
+                            : undefined,
+                        },
+                      },
+                    }))
+                  }
+                  placeholder="Leave empty to use HTML above"
+                />
+              </div>
+            </div>
+
+            <div className="flex items-center gap-3">
+              <Button type="button" variant="outline" onClick={previewAudience} disabled={audienceLoading}>
+                {audienceLoading ? (
+                  <Loader2 className="h-4 w-4 animate-spin mr-2" />
+                ) : (
+                  <RefreshCw className="h-4 w-4 mr-2" />
+                )}
+                Preview audience
+              </Button>
+              {audienceCount != null && (
+                <span className="text-sm text-muted-foreground">{audienceCount} matching subscribers</span>
+              )}
+            </div>
+          </div>
+
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setDialogOpen(false)}>
+              Cancel
+            </Button>
+            <Button onClick={handleSave} disabled={saving}>
+              {saving ? <Loader2 className="h-4 w-4 animate-spin mr-2" /> : null}
+              Save
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/app/(pages)/admin/campaigns/page.tsx
+++ b/app/(pages)/admin/campaigns/page.tsx
@@ -262,7 +262,7 @@ export default function AdminCampaignsPage() {
     try {
       base = requireApiBase();
     } catch (error) {
-      setTemplates([]);
+      // Keep templates null so reopening the dialog can retry.
       setTemplatesLoading(false);
       toast.error(errMessage(error, "Failed to load Brevo templates"));
       return;
@@ -277,7 +277,7 @@ export default function AdminCampaignsPage() {
       })
       .catch((error: unknown) => {
         if (controller.signal.aborted) return;
-        setTemplates([]);
+        // Keep templates null so a transient failure can retry on reopen.
         toast.error(errMessage(error, "Failed to load Brevo templates"));
       })
       .finally(() => {
@@ -373,11 +373,6 @@ export default function AdminCampaignsPage() {
       toast.error("Select at least one audience locale and role");
       return;
     }
-    const missingLocaleContent = form.locales.filter((locale) => !payload.content[locale]);
-    if (missingLocaleContent.length > 0) {
-      toast.error(`Provide content for every selected locale: ${missingLocaleContent.join(", ")}`);
-      return;
-    }
     const requestId = ++latestPreviewId.current;
     const requestKey = audienceKey;
     setAudienceLoading(true);
@@ -424,6 +419,11 @@ export default function AdminCampaignsPage() {
     }
     if (form.locales.length === 0 || form.roles.length === 0) {
       toast.error("Select at least one audience locale and role");
+      return;
+    }
+    const missingLocaleContent = form.locales.filter((locale) => !payload.content[locale]);
+    if (missingLocaleContent.length > 0) {
+      toast.error(`Provide content for every selected locale: ${missingLocaleContent.join(", ")}`);
       return;
     }
     if (form.scheduledAt && !payload.scheduledAt) {

--- a/app/(pages)/admin/campaigns/page.tsx
+++ b/app/(pages)/admin/campaigns/page.tsx
@@ -51,6 +51,12 @@ function toDatetimeLocalValue(iso: string): string {
   return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
 }
 
+function toScheduledIso(value: string): string | null {
+  if (!value) return null;
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? null : date.toISOString();
+}
+
 function requireApiBase(): string {
   if (!API_BASE) {
     throw new Error("NEXT_PUBLIC_BACKEND_URL is not configured");
@@ -63,6 +69,14 @@ interface LocaleContent {
   htmlContent: string;
   previewText?: string;
   brevoTemplateId?: number;
+}
+
+interface BrevoTemplate {
+  id: number;
+  name: string;
+  subject: string;
+  tag: string;
+  modifiedAt: string;
 }
 
 interface Campaign {
@@ -161,17 +175,26 @@ export default function AdminCampaignsPage() {
   const showPage = !authLoading && isAdmin && canManage;
 
   const [campaigns, setCampaigns] = useState<Campaign[]>([]);
+  const [page, setPage] = useState(1);
+  const [totalPages, setTotalPages] = useState(1);
   const [loading, setLoading] = useState(true);
   const [dialogOpen, setDialogOpen] = useState(false);
   const [editingId, setEditingId] = useState<string | null>(null);
   const [form, setForm] = useState<FormState>(emptyForm);
   const [saving, setSaving] = useState(false);
   const [activeLocaleTab, setActiveLocaleTab] = useState<Locale>("en");
-  const [audienceCount, setAudienceCount] = useState<number | null>(null);
+  const [audiencePreview, setAudiencePreview] = useState<{
+    count: number;
+    truncated: boolean;
+  } | null>(null);
   const [audienceLoading, setAudienceLoading] = useState(false);
   const [syncing, setSyncing] = useState(false);
+  const [templates, setTemplates] = useState<BrevoTemplate[] | null>(null);
+  const [templatesLoading, setTemplatesLoading] = useState(false);
   const [actionIds, setActionIds] = useState<Set<string>>(() => new Set());
   const latestLoadId = useRef(0);
+  const latestPreviewId = useRef(0);
+  const previewAudienceKey = useRef("");
 
   useEffect(() => {
     if (authLoading) return;
@@ -202,10 +225,18 @@ export default function AdminCampaignsPage() {
     const loadId = ++latestLoadId.current;
     setLoading(true);
     try {
-      const res = await authFetch(`${requireApiBase()}/api/admin/marketing-campaigns?limit=50`);
+      const res = await authFetch(
+        `${requireApiBase()}/api/admin/marketing-campaigns?page=${page}&limit=25`,
+      );
       const json = await res.json();
       if (!res.ok || !json.success) throw new Error(json.msg || "Failed to load");
       if (loadId === latestLoadId.current) {
+        const nextTotalPages = Math.max(1, Number(json.data.pagination?.totalPages) || 1);
+        setTotalPages(nextTotalPages);
+        if (page > nextTotalPages) {
+          setPage(nextTotalPages);
+          return;
+        }
         setCampaigns(json.data.campaigns || []);
       }
     } catch (e: unknown) {
@@ -217,17 +248,52 @@ export default function AdminCampaignsPage() {
         setLoading(false);
       }
     }
-  }, []);
+  }, [page]);
 
   useEffect(() => {
     if (showPage) load();
   }, [showPage, load]);
 
+  useEffect(() => {
+    if (!dialogOpen) return;
+    const controller = new AbortController();
+    setTemplatesLoading(true);
+    let base: string;
+    try {
+      base = requireApiBase();
+    } catch (error) {
+      setTemplates([]);
+      setTemplatesLoading(false);
+      toast.error(errMessage(error, "Failed to load Brevo templates"));
+      return;
+    }
+    authFetch(`${base}/api/admin/marketing-campaigns/templates`, {
+      signal: controller.signal,
+    })
+      .then(async (res) => {
+        const json = await res.json().catch(() => null);
+        if (!res.ok || !json?.success) throw new Error(json?.msg || "Template lookup failed");
+        if (!controller.signal.aborted) setTemplates(json.data?.templates || []);
+      })
+      .catch((error: unknown) => {
+        if (controller.signal.aborted) return;
+        setTemplates([]);
+        toast.error(errMessage(error, "Failed to load Brevo templates"));
+      })
+      .finally(() => {
+        if (!controller.signal.aborted) setTemplatesLoading(false);
+      });
+    return () => {
+      controller.abort();
+    };
+  }, [dialogOpen]);
+
   const openCreate = () => {
     setEditingId(null);
     setForm(emptyForm());
-    setAudienceCount(null);
+    setAudiencePreview(null);
     setActiveLocaleTab("en");
+    setTemplates(null);
     setDialogOpen(true);
   };
 
@@ -250,8 +316,9 @@ export default function AdminCampaignsPage() {
         fr: c.content?.fr || emptyContent(),
       },
     });
-    setAudienceCount(null);
+    setAudiencePreview(null);
     setActiveLocaleTab("en");
+    setTemplates(null);
     setDialogOpen(true);
   };
 
@@ -286,12 +353,30 @@ export default function AdminCampaignsPage() {
       content,
       inactiveDays: form.type === "reengagement" ? Number(form.inactiveDays) || 60 : undefined,
       autoSend: form.type === "reengagement" ? form.autoSend : false,
-      scheduledAt: form.scheduledAt ? new Date(form.scheduledAt).toISOString() : null,
+      scheduledAt: toScheduledIso(form.scheduledAt),
       utmCampaign: form.utmCampaign.trim() || undefined,
     };
   }, [form]);
 
+  const audienceKey = useMemo(
+    () => JSON.stringify([payload.audience, payload.inactiveDays]),
+    [payload.audience, payload.inactiveDays],
+  );
+
+  useEffect(() => {
+    previewAudienceKey.current = audienceKey;
+    latestPreviewId.current += 1;
+    setAudiencePreview(null);
+    setAudienceLoading(false);
+  }, [audienceKey]);
+
   const previewAudience = async () => {
+    if (form.locales.length === 0 || form.roles.length === 0) {
+      toast.error("Select at least one audience locale and role");
+      return;
+    }
+    const requestId = ++latestPreviewId.current;
+    const requestKey = audienceKey;
     setAudienceLoading(true);
     try {
       const res = await authFetch(`${requireApiBase()}/api/admin/marketing-campaigns/preview-audience`, {
@@ -304,17 +389,42 @@ export default function AdminCampaignsPage() {
       });
       const json = await res.json();
       if (!res.ok || !json.success) throw new Error(json.msg || "Preview failed");
-      setAudienceCount(json.data.count);
+      const nextPreview = {
+        count: Number(json.data.count) || 0,
+        truncated: Boolean(json.data.truncated),
+      };
+      if (
+        requestId !== latestPreviewId.current ||
+        requestKey !== previewAudienceKey.current
+      ) {
+        return;
+      }
+      setAudiencePreview(nextPreview);
+      if (nextPreview.truncated) {
+        toast.error("Audience exceeds the 5,000-recipient delivery limit");
+      }
     } catch (e: unknown) {
-      toast.error(errMessage(e, "Audience preview failed"));
+      if (requestId === latestPreviewId.current) {
+        toast.error(errMessage(e, "Audience preview failed"));
+      }
     } finally {
-      setAudienceLoading(false);
+      if (requestId === latestPreviewId.current) {
+        setAudienceLoading(false);
+      }
     }
   };
 
   const handleSave = async () => {
     if (!payload.name || Object.keys(payload.content).length === 0) {
-      toast.error("Name and at least one locale with subject + HTML are required");
+      toast.error("Name and at least one locale with subject and content are required");
+      return;
+    }
+    if (form.locales.length === 0 || form.roles.length === 0) {
+      toast.error("Select at least one audience locale and role");
+      return;
+    }
+    if (form.scheduledAt && !payload.scheduledAt) {
+      toast.error("Enter a valid schedule date and time");
       return;
     }
     setSaving(true);
@@ -385,7 +495,11 @@ export default function AdminCampaignsPage() {
       const json = await res.json();
       if (!res.ok || !json.success) throw new Error(json.msg || "Delete failed");
       toast.success("Deleted");
-      await load();
+      if (campaigns.length === 1 && page > 1) {
+        setPage((current) => current - 1);
+      } else {
+        await load();
+      }
     } catch (e: unknown) {
       toast.error(errMessage(e, "Delete failed"));
     } finally {
@@ -458,8 +572,13 @@ export default function AdminCampaignsPage() {
           </CardHeader>
         </Card>
       ) : (
-        <div className="space-y-3">
-          {campaigns.map((c) => {
+        <div className="space-y-4">
+          <div className="space-y-3">
+            {campaigns.map((c) => {
+            const hasStartedDelivery = (c.deliveries || []).some((delivery) =>
+              Boolean(delivery.brevoCampaignId),
+            );
+            const canMutate = ["draft", "scheduled", "failed"].includes(c.status) && !hasStartedDelivery;
             const totals = (c.deliveries || []).reduce(
               (acc, d) => {
                 acc.recipients += d.recipientCount || 0;
@@ -489,7 +608,7 @@ export default function AdminCampaignsPage() {
                       </CardDescription>
                     </div>
                     <div className="flex flex-wrap gap-2">
-                      {["draft", "scheduled", "failed"].includes(c.status) && (
+                      {canMutate && (
                         <Button size="sm" variant="outline" onClick={() => openEdit(c)}>
                           <Pencil className="h-3.5 w-3.5 mr-1" />
                           Edit
@@ -520,7 +639,7 @@ export default function AdminCampaignsPage() {
                           Refresh stats
                         </Button>
                       )}
-                      {c.status !== "sending" && (
+                      {canMutate && (
                         <Button
                           size="sm"
                           variant="ghost"
@@ -538,10 +657,43 @@ export default function AdminCampaignsPage() {
                   <div>Sent: {totals.sent}</div>
                   <div>Unique opens: {totals.opens}</div>
                   <div>Unique clicks: {totals.clicks}</div>
+                  {c.scheduledAt && (
+                    <div className="sm:col-span-4">
+                      Scheduled: {new Date(c.scheduledAt).toLocaleString()}
+                    </div>
+                  )}
                 </CardContent>
               </Card>
             );
-          })}
+            })}
+          </div>
+          {totalPages > 1 && (
+            <div className="flex items-center justify-between">
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                disabled={page <= 1 || loading}
+                onClick={() => setPage((current) => Math.max(1, current - 1))}
+              >
+                Previous
+              </Button>
+              <span className="text-sm text-muted-foreground">
+                Page {page} of {totalPages}
+              </span>
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                disabled={page >= totalPages || loading}
+                onClick={() =>
+                  setPage((current) => Math.min(totalPages, current + 1))
+                }
+              >
+                Next
+              </Button>
+            </div>
+          )}
         </div>
       )}
 
@@ -612,7 +764,9 @@ export default function AdminCampaignsPage() {
                         ...f,
                         locales: checked
                           ? Array.from(new Set([...f.locales, locale]))
-                          : f.locales.filter((l) => l !== locale),
+                          : f.locales.length > 1
+                            ? f.locales.filter((l) => l !== locale)
+                            : f.locales,
                       }))
                     }
                   />
@@ -631,7 +785,9 @@ export default function AdminCampaignsPage() {
                         ...f,
                         roles: checked
                           ? Array.from(new Set([...f.roles, role]))
-                          : f.roles.filter((r) => r !== role),
+                          : f.roles.length > 1
+                            ? f.roles.filter((r) => r !== role)
+                            : f.roles,
                       }))
                     }
                   />
@@ -738,7 +894,7 @@ export default function AdminCampaignsPage() {
                 />
               </div>
               <div className="space-y-2">
-                <Label>HTML body (or leave minimal if using Brevo template id)</Label>
+                <Label>HTML body</Label>
                 <Textarea
                   className="min-h-[160px] font-mono text-xs"
                   value={form.content[activeLocaleTab].htmlContent}
@@ -758,26 +914,56 @@ export default function AdminCampaignsPage() {
                 />
               </div>
               <div className="space-y-2">
-                <Label>Brevo template id (optional)</Label>
-                <Input
-                  type="number"
-                  value={form.content[activeLocaleTab].brevoTemplateId ?? ""}
-                  onChange={(e) =>
+                <Label>Brevo template</Label>
+                <Select
+                  value={String(form.content[activeLocaleTab].brevoTemplateId || "inline")}
+                  disabled={templatesLoading}
+                  onValueChange={(value) =>
                     setForm((f) => ({
                       ...f,
                       content: {
                         ...f.content,
                         [activeLocaleTab]: {
                           ...f.content[activeLocaleTab],
-                          brevoTemplateId: e.target.value
-                            ? Number(e.target.value)
-                            : undefined,
+                          brevoTemplateId: value === "inline" ? undefined : Number(value),
+                          subject:
+                            f.content[activeLocaleTab].subject ||
+                            templates?.find((template) => String(template.id) === value)?.subject ||
+                            "",
                         },
                       },
                     }))
                   }
-                  placeholder="Leave empty to use HTML above"
-                />
+                >
+                  <SelectTrigger>
+                    <SelectValue
+                      placeholder={templatesLoading ? "Loading templates..." : "Use inline HTML"}
+                    />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="inline">Use inline HTML</SelectItem>
+                    {form.content[activeLocaleTab].brevoTemplateId &&
+                      !(templates || []).some(
+                        (template) =>
+                          template.id ===
+                          form.content[activeLocaleTab].brevoTemplateId,
+                      ) && (
+                        <SelectItem
+                          value={String(
+                            form.content[activeLocaleTab].brevoTemplateId,
+                          )}
+                        >
+                          Template #
+                          {form.content[activeLocaleTab].brevoTemplateId} (inactive)
+                        </SelectItem>
+                      )}
+                    {(templates || []).map((template) => (
+                      <SelectItem key={template.id} value={String(template.id)}>
+                        {template.name} (#{template.id})
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
               </div>
             </div>
 
@@ -790,8 +976,17 @@ export default function AdminCampaignsPage() {
                 )}
                 Preview audience
               </Button>
-              {audienceCount != null && (
-                <span className="text-sm text-muted-foreground">{audienceCount} matching subscribers</span>
+              {audiencePreview && (
+                <span
+                  className={
+                    audiencePreview.truncated
+                      ? "text-sm text-rose-600"
+                      : "text-sm text-muted-foreground"
+                  }
+                >
+                  {audiencePreview.count} matching subscribers
+                  {audiencePreview.truncated ? " (over 5,000 limit)" : ""}
+                </span>
               )}
             </div>
           </div>

--- a/app/(pages)/admin/campaigns/page.tsx
+++ b/app/(pages)/admin/campaigns/page.tsx
@@ -33,11 +33,30 @@ import {
   BarChart3,
 } from "lucide-react";
 import { toast } from "sonner";
+import { useAdminAccess } from "@/hooks/useAdminAccess";
 
-const API_BASE = process.env.NEXT_PUBLIC_BACKEND_URL || "http://localhost:4000";
+const API_BASE = process.env.NEXT_PUBLIC_BACKEND_URL || "";
 const LOCALES = ["en", "nl", "fr"] as const;
 type Locale = (typeof LOCALES)[number];
 type CampaignType = "newsletter" | "promotion" | "reengagement";
+
+function errMessage(e: unknown, fallback: string): string {
+  return e instanceof Error && e.message ? e.message : fallback;
+}
+
+function toDatetimeLocalValue(iso: string): string {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return "";
+  const pad = (n: number) => String(n).padStart(2, "0");
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
+}
+
+function requireApiBase(): string {
+  if (!API_BASE) {
+    throw new Error("NEXT_PUBLIC_BACKEND_URL is not configured");
+  }
+  return API_BASE;
+}
 
 interface LocaleContent {
   subject: string;
@@ -135,7 +154,12 @@ const statusColor = (status: string) => {
 
 export default function AdminCampaignsPage() {
   const router = useRouter();
-  const { user, loading: authLoading } = useAuth();
+  const { user, isAuthenticated, loading: authLoading } = useAuth();
+  const { canAccessPath } = useAdminAccess();
+  const canManage = canAccessPath("/admin/campaigns");
+  const isAdmin = Boolean(isAuthenticated && user?.role === "admin");
+  const showPage = !authLoading && isAdmin && canManage;
+
   const [campaigns, setCampaigns] = useState<Campaign[]>([]);
   const [loading, setLoading] = useState(true);
   const [dialogOpen, setDialogOpen] = useState(false);
@@ -146,29 +170,50 @@ export default function AdminCampaignsPage() {
   const [audienceCount, setAudienceCount] = useState<number | null>(null);
   const [audienceLoading, setAudienceLoading] = useState(false);
   const [syncing, setSyncing] = useState(false);
-  const [actionId, setActionId] = useState<string | null>(null);
+  const [actionIds, setActionIds] = useState<Set<string>>(() => new Set());
 
   useEffect(() => {
-    if (!authLoading && user?.role !== "admin") router.replace("/");
-  }, [authLoading, user, router]);
+    if (authLoading) return;
+    if (!isAdmin) {
+      router.replace("/login");
+      return;
+    }
+    if (!canManage) router.replace("/dashboard");
+  }, [authLoading, isAdmin, canManage, router]);
+
+  const beginAction = (id: string) => {
+    setActionIds((prev) => {
+      const next = new Set(prev);
+      next.add(id);
+      return next;
+    });
+  };
+
+  const endAction = (id: string) => {
+    setActionIds((prev) => {
+      const next = new Set(prev);
+      next.delete(id);
+      return next;
+    });
+  };
 
   const load = useCallback(async () => {
     setLoading(true);
     try {
-      const res = await authFetch(`${API_BASE}/api/admin/marketing-campaigns?limit=50`);
+      const res = await authFetch(`${requireApiBase()}/api/admin/marketing-campaigns?limit=50`);
       const json = await res.json();
       if (!res.ok || !json.success) throw new Error(json.msg || "Failed to load");
       setCampaigns(json.data.campaigns || []);
-    } catch (e: any) {
-      toast.error(e.message || "Failed to load campaigns");
+    } catch (e: unknown) {
+      toast.error(errMessage(e, "Failed to load campaigns"));
     } finally {
       setLoading(false);
     }
   }, []);
 
   useEffect(() => {
-    if (user?.role === "admin") load();
-  }, [user, load]);
+    if (showPage) load();
+  }, [showPage, load]);
 
   const openCreate = () => {
     setEditingId(null);
@@ -189,7 +234,7 @@ export default function AdminCampaignsPage() {
       roles: c.audience?.roles?.length ? c.audience.roles : ["customer", "professional"],
       inactiveDays: String(c.inactiveDays || 60),
       autoSend: Boolean(c.autoSend),
-      scheduledAt: c.scheduledAt ? c.scheduledAt.slice(0, 16) : "",
+      scheduledAt: c.scheduledAt ? toDatetimeLocalValue(c.scheduledAt) : "",
       utmCampaign: c.utmCampaign || "",
       content: {
         en: c.content?.en || emptyContent(),
@@ -241,7 +286,7 @@ export default function AdminCampaignsPage() {
   const previewAudience = async () => {
     setAudienceLoading(true);
     try {
-      const res = await authFetch(`${API_BASE}/api/admin/marketing-campaigns/preview-audience`, {
+      const res = await authFetch(`${requireApiBase()}/api/admin/marketing-campaigns/preview-audience`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
@@ -252,8 +297,8 @@ export default function AdminCampaignsPage() {
       const json = await res.json();
       if (!res.ok || !json.success) throw new Error(json.msg || "Preview failed");
       setAudienceCount(json.data.count);
-    } catch (e: any) {
-      toast.error(e.message || "Audience preview failed");
+    } catch (e: unknown) {
+      toast.error(errMessage(e, "Audience preview failed"));
     } finally {
       setAudienceLoading(false);
     }
@@ -266,9 +311,10 @@ export default function AdminCampaignsPage() {
     }
     setSaving(true);
     try {
+      const base = requireApiBase();
       const url = editingId
-        ? `${API_BASE}/api/admin/marketing-campaigns/${editingId}`
-        : `${API_BASE}/api/admin/marketing-campaigns`;
+        ? `${base}/api/admin/marketing-campaigns/${editingId}`
+        : `${base}/api/admin/marketing-campaigns`;
       const res = await authFetch(url, {
         method: editingId ? "PATCH" : "POST",
         headers: { "Content-Type": "application/json" },
@@ -279,8 +325,8 @@ export default function AdminCampaignsPage() {
       toast.success(editingId ? "Campaign updated" : "Campaign created");
       setDialogOpen(false);
       await load();
-    } catch (e: any) {
-      toast.error(e.message || "Save failed");
+    } catch (e: unknown) {
+      toast.error(errMessage(e, "Save failed"));
     } finally {
       setSaving(false);
     }
@@ -288,61 +334,61 @@ export default function AdminCampaignsPage() {
 
   const handleSend = async (id: string) => {
     if (!confirm("Send this campaign now via Brevo to the matched audience?")) return;
-    setActionId(id);
+    beginAction(id);
     try {
-      const res = await authFetch(`${API_BASE}/api/admin/marketing-campaigns/${id}/send`, {
+      const res = await authFetch(`${requireApiBase()}/api/admin/marketing-campaigns/${id}/send`, {
         method: "POST",
       });
       const json = await res.json();
       if (!res.ok || !json.success) throw new Error(json.msg || "Send failed");
       toast.success("Campaign sent");
       await load();
-    } catch (e: any) {
-      toast.error(e.message || "Send failed");
+    } catch (e: unknown) {
+      toast.error(errMessage(e, "Send failed"));
     } finally {
-      setActionId(null);
+      endAction(id);
     }
   };
 
   const handleStats = async (id: string) => {
-    setActionId(id);
+    beginAction(id);
     try {
-      const res = await authFetch(`${API_BASE}/api/admin/marketing-campaigns/${id}/stats`, {
+      const res = await authFetch(`${requireApiBase()}/api/admin/marketing-campaigns/${id}/stats`, {
         method: "POST",
       });
       const json = await res.json();
       if (!res.ok || !json.success) throw new Error(json.msg || "Refresh failed");
       toast.success("Stats refreshed from Brevo");
       await load();
-    } catch (e: any) {
-      toast.error(e.message || "Refresh failed");
+    } catch (e: unknown) {
+      toast.error(errMessage(e, "Refresh failed"));
     } finally {
-      setActionId(null);
+      endAction(id);
     }
   };
 
   const handleDelete = async (id: string) => {
     if (!confirm("Delete this campaign?")) return;
-    setActionId(id);
+    beginAction(id);
     try {
-      const res = await authFetch(`${API_BASE}/api/admin/marketing-campaigns/${id}`, {
+      const res = await authFetch(`${requireApiBase()}/api/admin/marketing-campaigns/${id}`, {
         method: "DELETE",
       });
       const json = await res.json();
       if (!res.ok || !json.success) throw new Error(json.msg || "Delete failed");
       toast.success("Deleted");
       await load();
-    } catch (e: any) {
-      toast.error(e.message || "Delete failed");
+    } catch (e: unknown) {
+      toast.error(errMessage(e, "Delete failed"));
     } finally {
-      setActionId(null);
+      endAction(id);
     }
   };
 
   const syncSubscribers = async () => {
     setSyncing(true);
     try {
-      const res = await authFetch(`${API_BASE}/api/admin/marketing-subscribers/sync`, {
+      const res = await authFetch(`${requireApiBase()}/api/admin/marketing-subscribers/sync`, {
         method: "POST",
       });
       const json = await res.json();
@@ -350,14 +396,14 @@ export default function AdminCampaignsPage() {
       toast.success(
         `Synced subscribers (upserted ${json.data.upserted}, unsubscribed ${json.data.unsubscribed})`,
       );
-    } catch (e: any) {
-      toast.error(e.message || "Sync failed");
+    } catch (e: unknown) {
+      toast.error(errMessage(e, "Sync failed"));
     } finally {
       setSyncing(false);
     }
   };
 
-  if (authLoading || (user && user.role !== "admin")) {
+  if (authLoading || !showPage) {
     return (
       <div className="p-8">
         <Skeleton className="h-10 w-64 mb-4" />
@@ -445,9 +491,9 @@ export default function AdminCampaignsPage() {
                         <Button
                           size="sm"
                           onClick={() => handleSend(c._id)}
-                          disabled={actionId === c._id}
+                          disabled={actionIds.has(c._id)}
                         >
-                          {actionId === c._id ? (
+                          {actionIds.has(c._id) ? (
                             <Loader2 className="h-3.5 w-3.5 animate-spin mr-1" />
                           ) : (
                             <Send className="h-3.5 w-3.5 mr-1" />
@@ -460,7 +506,7 @@ export default function AdminCampaignsPage() {
                           size="sm"
                           variant="outline"
                           onClick={() => handleStats(c._id)}
-                          disabled={actionId === c._id}
+                          disabled={actionIds.has(c._id)}
                         >
                           <BarChart3 className="h-3.5 w-3.5 mr-1" />
                           Refresh stats
@@ -471,7 +517,7 @@ export default function AdminCampaignsPage() {
                           size="sm"
                           variant="ghost"
                           onClick={() => handleDelete(c._id)}
-                          disabled={actionId === c._id}
+                          disabled={actionIds.has(c._id)}
                         >
                           <Trash2 className="h-3.5 w-3.5 text-rose-500" />
                         </Button>

--- a/app/(pages)/admin/campaigns/page.tsx
+++ b/app/(pages)/admin/campaigns/page.tsx
@@ -255,7 +255,7 @@ export default function AdminCampaignsPage() {
   }, [showPage, load]);
 
   useEffect(() => {
-    if (!dialogOpen) return;
+    if (!dialogOpen || templates !== null) return;
     const controller = new AbortController();
     setTemplatesLoading(true);
     let base: string;
@@ -286,14 +286,13 @@ export default function AdminCampaignsPage() {
     return () => {
       controller.abort();
     };
-  }, [dialogOpen]);
+  }, [dialogOpen, templates]);
 
   const openCreate = () => {
     setEditingId(null);
     setForm(emptyForm());
     setAudiencePreview(null);
     setActiveLocaleTab("en");
-    setTemplates(null);
     setDialogOpen(true);
   };
 
@@ -318,7 +317,6 @@ export default function AdminCampaignsPage() {
     });
     setAudiencePreview(null);
     setActiveLocaleTab("en");
-    setTemplates(null);
     setDialogOpen(true);
   };
 
@@ -373,6 +371,11 @@ export default function AdminCampaignsPage() {
   const previewAudience = async () => {
     if (form.locales.length === 0 || form.roles.length === 0) {
       toast.error("Select at least one audience locale and role");
+      return;
+    }
+    const missingLocaleContent = form.locales.filter((locale) => !payload.content[locale]);
+    if (missingLocaleContent.length > 0) {
+      toast.error(`Provide content for every selected locale: ${missingLocaleContent.join(", ")}`);
       return;
     }
     const requestId = ++latestPreviewId.current;

--- a/app/(pages)/admin/chat/page.tsx
+++ b/app/(pages)/admin/chat/page.tsx
@@ -54,6 +54,8 @@ function AdminChatInner() {
   const conversationId = selectedId
 
   const [inboxFilter, setInboxFilter] = useState<InboxFilter>('all')
+  const [inboxPage, setInboxPage] = useState(1)
+  const [inboxTotal, setInboxTotal] = useState(0)
   const [conversations, setConversations] = useState<AdminConversationListItem[]>([])
   const [listLoading, setListLoading] = useState(true)
   const [conversation, setConversation] = useState<AdminConversation | null>(null)
@@ -86,12 +88,23 @@ function AdminChatInner() {
     const requestId = ++inboxRequestIdRef.current
     if (!silent) setListLoading(true)
     try {
-      const qs = inboxFilter === 'mine' ? '?mine=true' : ''
-      const res = await authFetch(`${BACKEND}/api/admin/conversations${qs}`)
+      const qs = new URLSearchParams({
+        page: String(inboxPage),
+        limit: '20',
+      })
+      if (inboxFilter === 'mine') qs.set('mine', 'true')
+      const res = await authFetch(`${BACKEND}/api/admin/conversations?${qs}`)
       const json = await res.json()
       if (requestId !== inboxRequestIdRef.current) return
       if (!res.ok || !json?.success) {
         throw new Error(json?.msg || "Failed to load conversations")
+      }
+      const nextTotal = Math.max(0, Number(json.data?.total) || 0)
+      const lastPage = Math.max(1, Math.ceil(nextTotal / 20))
+      setInboxTotal(nextTotal)
+      if (inboxPage > lastPage) {
+        setInboxPage(lastPage)
+        return
       }
       setConversations(Array.isArray(json.data?.items) ? json.data.items : [])
     } catch {
@@ -105,6 +118,10 @@ function AdminChatInner() {
         setListLoading(false)
       }
     }
+  }, [inboxFilter, inboxPage])
+
+  useEffect(() => {
+    setInboxPage(1)
   }, [inboxFilter])
 
   const load = useCallback(async (silent = false) => {
@@ -124,12 +141,16 @@ function AdminChatInner() {
       const convJson = await convRes.json()
       const msgJson = await msgRes.json()
       if (conversationId !== selectedIdRef.current) return
-      if (convJson?.success) setConversation(convJson.data)
-      if (msgJson?.success) {
-        const items = Array.isArray(msgJson.data?.items) ? msgJson.data.items : []
-        setMessages(items)
-        markAdminConversationSeen(conversationId)
+      if (!convRes.ok || !convJson?.success) {
+        throw new Error(convJson?.msg || "Failed to load conversation")
       }
+      if (!msgRes.ok || !msgJson?.success) {
+        throw new Error(msgJson?.msg || "Failed to load messages")
+      }
+      setConversation(convJson.data)
+      const items = Array.isArray(msgJson.data?.items) ? msgJson.data.items : []
+      setMessages(items)
+      markAdminConversationSeen(conversationId)
       setLoadError(null)
     } catch {
       if (!silent) {
@@ -329,6 +350,37 @@ function AdminChatInner() {
                     )
                   })}
                 </ul>
+              )}
+              {(inboxTotal > 20 || inboxPage > 1) && (
+                <div className="sticky bottom-0 flex items-center justify-between border-t bg-white px-3 py-2">
+                  <Button
+                    type="button"
+                    size="sm"
+                    variant="outline"
+                    className="h-7 px-2 text-xs"
+                    disabled={inboxPage <= 1 || listLoading}
+                    onClick={() => setInboxPage((current) => Math.max(1, current - 1))}
+                  >
+                    Previous
+                  </Button>
+                  <span className="text-xs text-gray-500">
+                    {inboxPage} / {Math.max(1, Math.ceil(inboxTotal / 20))}
+                  </span>
+                  <Button
+                    type="button"
+                    size="sm"
+                    variant="outline"
+                    className="h-7 px-2 text-xs"
+                    disabled={inboxPage >= Math.max(1, Math.ceil(inboxTotal / 20)) || listLoading}
+                    onClick={() =>
+                      setInboxPage((current) =>
+                        Math.min(Math.max(1, Math.ceil(inboxTotal / 20)), current + 1),
+                      )
+                    }
+                  >
+                    Next
+                  </Button>
+                </div>
               )}
             </CardContent>
           </Card>

--- a/app/(pages)/admin/kpi/page.tsx
+++ b/app/(pages)/admin/kpi/page.tsx
@@ -423,7 +423,10 @@ export default function AdminKpiDashboard() {
       return
     }
     try {
-      const res = await authFetch(`${BACKEND}/api/admin/kpi/export?section=${section}&format=${fmt}&${appliedRange}`)
+      const limit = section === 'response' ? '&limit=50' : ''
+      const res = await authFetch(
+        `${BACKEND}/api/admin/kpi/export?section=${section}&format=${fmt}&${appliedRange}${limit}`,
+      )
       if (!res.ok) {
         const json = await res.json().catch(() => ({}))
         toast.error(json?.error?.message || 'Failed to download')

--- a/app/(pages)/admin/site-announcements/page.tsx
+++ b/app/(pages)/admin/site-announcements/page.tsx
@@ -17,6 +17,9 @@ export default function AdminSiteAnnouncementsPage() {
     filters,
     patchFilters,
     items,
+    page,
+    total,
+    setPage,
     listLoading,
     editor,
     openCreate,
@@ -56,6 +59,9 @@ export default function AdminSiteAnnouncementsPage() {
 
       <AnnouncementsCard
         items={items}
+        page={page}
+        total={total}
+        onPageChange={setPage}
         loading={listLoading}
         filters={filters}
         onFiltersChange={patchFilters}

--- a/app/(pages)/admin/staff/page.tsx
+++ b/app/(pages)/admin/staff/page.tsx
@@ -93,7 +93,7 @@ function StaffPageInner() {
   }, []);
 
   useEffect(() => {
-    void load();
+    void load().catch(() => undefined);
   }, [load]);
 
   const applyInviteResponse = (

--- a/app/(pages)/dashboard/page.tsx
+++ b/app/(pages)/dashboard/page.tsx
@@ -639,7 +639,7 @@ export default function DashboardPage() {
                   </div>
                 </TabsTrigger>
               )}
-              {defaultAdminTab === 'tools' && (
+              {adminToolLinks.length > 0 && (
                 <TabsTrigger
                   value="tools"
                   className="group min-h-[88px] justify-start rounded-2xl border-0 bg-gradient-to-r from-slate-600 to-slate-800 px-5 py-4 text-left text-white shadow-md transition-all duration-200 hover:-translate-y-1 hover:shadow-xl"
@@ -1641,7 +1641,7 @@ export default function DashboardPage() {
             </TabsContent>
             )}
 
-            {defaultAdminTab === 'tools' && (
+            {adminToolLinks.length > 0 && (
               <TabsContent value="tools" className="space-y-6">
                 <Card>
                   <CardHeader>

--- a/app/(pages)/dashboard/page.tsx
+++ b/app/(pages)/dashboard/page.tsx
@@ -346,21 +346,23 @@ export default function DashboardPage() {
       }
 
       // Fetch warranty analytics separately so its failure doesn't block other cards
-      if (canManageWarranty) try {
-        const warrantyResponse = await fetch(
-          `${process.env.NEXT_PUBLIC_BACKEND_URL}/api/warranty-claims/admin/analytics`,
-          fetchOptions
-        )
-        if (warrantyResponse.ok) {
-          const warrantyData = await warrantyResponse.json()
-          if (warrantyData.success) {
-            setWarrantyAnalytics(warrantyData.data || null)
-          } else {
-            console.error('[Dashboard] Warranty analytics returned success: false', warrantyData.msg)
+      if (canManageWarranty) {
+        try {
+          const warrantyResponse = await fetch(
+            `${process.env.NEXT_PUBLIC_BACKEND_URL}/api/warranty-claims/admin/analytics`,
+            fetchOptions
+          )
+          if (warrantyResponse.ok) {
+            const warrantyData = await warrantyResponse.json()
+            if (warrantyData.success) {
+              setWarrantyAnalytics(warrantyData.data || null)
+            } else {
+              console.error('[Dashboard] Warranty analytics returned success: false', warrantyData.msg)
+            }
           }
+        } catch (warrantyErr) {
+          console.error('[Dashboard] Failed to fetch warranty analytics:', warrantyErr)
         }
-      } catch (warrantyErr) {
-        console.error('[Dashboard] Failed to fetch warranty analytics:', warrantyErr)
       }
 
     } catch (error) {

--- a/app/(pages)/dashboard/page.tsx
+++ b/app/(pages)/dashboard/page.tsx
@@ -161,6 +161,25 @@ export default function DashboardPage() {
   const canManageServices = can('services.manage')
   const canManagePayments = can('payments.manage')
   const canRunMaintenance = can('maintenance.run')
+  const adminToolLinks = [
+    { path: '/admin/campaigns', label: 'Email Campaigns' },
+    { path: '/admin/cms', label: 'CMS Content' },
+    { path: '/admin/site-announcements', label: 'Site Announcements' },
+    { path: '/admin/chat', label: 'Support Chat' },
+    { path: '/admin/customers', label: 'Customers' },
+    { path: '/admin/bookings', label: 'Bookings' },
+    { path: '/admin/disputes', label: 'Disputes' },
+    { path: '/admin/cancellation-requests', label: 'Cancellation Requests' },
+    { path: '/admin/warranty-claims', label: 'Warranty Claims' },
+    { path: '/admin/support', label: 'Support Tickets' },
+    { path: '/admin/discount-codes', label: 'Discount Codes' },
+    { path: '/admin/referral', label: 'Referrals' },
+    { path: '/admin/backlinks', label: 'Backlinks' },
+    { path: '/admin/favorites', label: 'Favorites' },
+    { path: '/admin/kpi', label: 'KPI Reports' },
+    { path: '/admin/audit-logs', label: 'Audit Logs' },
+    { path: '/admin/email-logs', label: 'Email Logs' },
+  ].filter(({ path }) => canAccessPath(path))
   const defaultAdminTab = canViewAdminOverview
     ? 'overview'
     : canManageServices
@@ -171,7 +190,9 @@ export default function DashboardPage() {
           ? 'approvals'
           : canManagePayments
             ? 'payments'
-            : undefined
+            : adminToolLinks.length > 0
+              ? 'tools'
+              : undefined
 
   const actionItems = useMemo(() => getProfessionalActionItems(bookings), [bookings])
   const warrantyActionItems = useMemo<WarrantyDashboardAction[]>(() => {
@@ -613,6 +634,17 @@ export default function DashboardPage() {
                       <div className="font-semibold text-white">Payments</div>
                       <div className="mt-0.5 text-xs leading-5 text-white/85">Open payment oversight</div>
                     </div>
+                  </div>
+                </TabsTrigger>
+              )}
+              {defaultAdminTab === 'tools' && (
+                <TabsTrigger
+                  value="tools"
+                  className="group min-h-[88px] justify-start rounded-2xl border-0 bg-gradient-to-r from-slate-600 to-slate-800 px-5 py-4 text-left text-white shadow-md transition-all duration-200 hover:-translate-y-1 hover:shadow-xl"
+                >
+                  <div>
+                    <div className="font-semibold">Admin tools</div>
+                    <div className="mt-0.5 text-xs leading-5 text-white/85">Open permitted areas</div>
                   </div>
                 </TabsTrigger>
               )}
@@ -1605,6 +1637,24 @@ export default function DashboardPage() {
                 </CardContent>
               </Card>
             </TabsContent>
+            )}
+
+            {defaultAdminTab === 'tools' && (
+              <TabsContent value="tools" className="space-y-6">
+                <Card>
+                  <CardHeader>
+                    <CardTitle>Available admin tools</CardTitle>
+                    <CardDescription>Choose an area your role is allowed to manage.</CardDescription>
+                  </CardHeader>
+                  <CardContent className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+                    {adminToolLinks.map((tool) => (
+                      <Button key={tool.path} variant="outline" onClick={() => openAdmin(tool.path)}>
+                        {tool.label}
+                      </Button>
+                    ))}
+                  </CardContent>
+                </Card>
+              </TabsContent>
             )}
 
           </Tabs>

--- a/app/(pages)/dashboard/page.tsx
+++ b/app/(pages)/dashboard/page.tsx
@@ -6,7 +6,7 @@ import { Button } from "@/components/ui/button"
 import { Badge } from "@/components/ui/badge"
 import { User, Mail, Phone, Shield, Calendar, Crown, Settings, TrendingUp, Users, Award, CheckCircle, XCircle, Clock, AlertTriangle, Plus, Briefcase, Package, CreditCard, FileText, Star, Gift, Play, Loader2, Info, MessageSquareWarning, EyeOff, Heart, LifeBuoy, Ticket, BarChart3, Ban, AlertOctagon, Link2, MessageSquare, Megaphone } from "lucide-react"
 import { useRouter } from "next/navigation"
-import { useEffect, useMemo, useState } from "react"
+import { useCallback, useEffect, useMemo, useState } from "react"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import Link from "next/link"
 import { getAuthToken } from "@/lib/utils"
@@ -153,6 +153,25 @@ export default function DashboardPage() {
   const [warrantyClaims, setWarrantyClaims] = useState<WarrantyClaimAction[]>([])
   const [warrantyClaimsLoading, setWarrantyClaimsLoading] = useState(false)
   const [warrantyClaimsError, setWarrantyClaimsError] = useState<string | null>(null)
+  const canViewAdminOverview = can('dashboard.overview')
+  const canManageLoyalty = can('loyalty.manage')
+  const canApproveProfessionals = can('professionals.approve')
+  const canApproveProjects = can('projects.approve')
+  const canManageWarranty = can('warranty.manage')
+  const canManageServices = can('services.manage')
+  const canManagePayments = can('payments.manage')
+  const canRunMaintenance = can('maintenance.run')
+  const defaultAdminTab = canViewAdminOverview
+    ? 'overview'
+    : canManageServices
+      ? 'services'
+      : canManageLoyalty
+        ? 'loyalty'
+        : canApproveProfessionals
+          ? 'approvals'
+          : canManagePayments
+            ? 'payments'
+            : undefined
 
   const actionItems = useMemo(() => getProfessionalActionItems(bookings), [bookings])
   const warrantyActionItems = useMemo<WarrantyDashboardAction[]>(() => {
@@ -176,13 +195,6 @@ export default function DashboardPage() {
       router.push('/login?redirect=/dashboard')
     }
   }, [isAuthenticated, loading, router])
-
-  // Fetch admin-specific data
-  useEffect(() => {
-    if (user?.role === 'admin') {
-      fetchAdminData()
-    }
-  }, [user])
 
   // Fetch bookings for professional dashboard only (CustomerDashboard fetches its own)
   useEffect(() => {
@@ -270,8 +282,13 @@ export default function DashboardPage() {
     void loadClaims()
   }, [user, isAuthenticated])
 
-  const fetchAdminData = async () => {
+  const fetchAdminData = useCallback(async () => {
     setIsLoadingStats(true)
+    if (!canManageLoyalty) setLoyaltyStats(null)
+    if (!canApproveProfessionals) setApprovalStats(null)
+    if (!canApproveProjects) setProjectStats(null)
+    if (!canManageWarranty) setWarrantyAnalytics(null)
+
     try {
       // Get token for Authorization header fallback
       const token = getAuthToken()
@@ -281,28 +298,34 @@ export default function DashboardPage() {
       }
 
       const [loyaltyResponse, approvalResponse, projectsResponse] = await Promise.all([
-        fetch(`${process.env.NEXT_PUBLIC_BACKEND_URL}/api/admin/loyalty/analytics`, fetchOptions),
-        fetch(`${process.env.NEXT_PUBLIC_BACKEND_URL}/api/admin/stats/approvals`, fetchOptions),
-        fetch(`${process.env.NEXT_PUBLIC_BACKEND_URL}/api/projects/admin/pending`, fetchOptions),
+        canManageLoyalty
+          ? fetch(`${process.env.NEXT_PUBLIC_BACKEND_URL}/api/admin/loyalty/analytics`, fetchOptions)
+          : Promise.resolve(null),
+        canApproveProfessionals
+          ? fetch(`${process.env.NEXT_PUBLIC_BACKEND_URL}/api/admin/stats/approvals`, fetchOptions)
+          : Promise.resolve(null),
+        canApproveProjects
+          ? fetch(`${process.env.NEXT_PUBLIC_BACKEND_URL}/api/projects/admin/pending`, fetchOptions)
+          : Promise.resolve(null),
       ])
 
-      if (loyaltyResponse.ok) {
+      if (loyaltyResponse?.ok) {
         const loyaltyData = await loyaltyResponse.json()
         setLoyaltyStats(loyaltyData.data)
       }
 
-      if (approvalResponse.ok) {
+      if (approvalResponse?.ok) {
         const approvalData = await approvalResponse.json()
         setApprovalStats(approvalData.data.stats)
       }
 
-      if (projectsResponse.ok) {
+      if (projectsResponse?.ok) {
         const projectsData = await projectsResponse.json()
         setProjectStats({ pendingProjects: projectsData.length })
       }
 
       // Fetch warranty analytics separately so its failure doesn't block other cards
-      try {
+      if (canManageWarranty) try {
         const warrantyResponse = await fetch(
           `${process.env.NEXT_PUBLIC_BACKEND_URL}/api/warranty-claims/admin/analytics`,
           fetchOptions
@@ -324,9 +347,20 @@ export default function DashboardPage() {
     } finally {
       setIsLoadingStats(false)
     }
-  }
+  }, [canApproveProfessionals, canApproveProjects, canManageLoyalty, canManageWarranty])
+
+  // Fetch only the admin data represented by the current permission pack.
+  useEffect(() => {
+    if (user?.role === 'admin') {
+      void fetchAdminData()
+    }
+  }, [fetchAdminData, user?.role])
 
   const runSchedulerCheck = async (type: 'warranty' | 'rfq' | 'notif' | 'autoaccept') => {
+    if (!canRunMaintenance) {
+      toast.error('Your role cannot run maintenance jobs')
+      return
+    }
     const loadingMap = {
       warranty: setIsRunningWarrantyCheck,
       rfq: setIsRunningRfqCheck,
@@ -475,29 +509,34 @@ export default function DashboardPage() {
                   Staff & roles
                 </Link>
               )}
-              <Link
-                className="inline-flex items-center gap-2 rounded-xl bg-gradient-to-r from-indigo-600 via-purple-600 to-fuchsia-600 px-4 py-2 text-sm font-semibold text-white shadow-md transition-all duration-200 hover:-translate-y-0.5 hover:shadow-xl"
-                href='/admin/kpi'
-              >
-                <BarChart3 className="h-4 w-4" />
-                View KPI Dashboard
-              </Link>
-              <Link
-                className="text-pink-800 underline flex items-center gap-2"
-                href='/admin/projects/approval'
-              >
-                Approve Projects
-                {projectStats && projectStats.pendingProjects > 0 && (
-                  <span className="inline-flex items-center justify-center px-2 py-1 text-xs font-bold leading-none text-white bg-red-600 rounded-full">
-                    {projectStats.pendingProjects}
-                  </span>
-                )}
-              </Link>
+              {can('kpi.read') && (
+                <Link
+                  className="inline-flex items-center gap-2 rounded-xl bg-gradient-to-r from-indigo-600 via-purple-600 to-fuchsia-600 px-4 py-2 text-sm font-semibold text-white shadow-md transition-all duration-200 hover:-translate-y-0.5 hover:shadow-xl"
+                  href='/admin/kpi'
+                >
+                  <BarChart3 className="h-4 w-4" />
+                  View KPI Dashboard
+                </Link>
+              )}
+              {canApproveProjects && (
+                <Link
+                  className="text-pink-800 underline flex items-center gap-2"
+                  href='/admin/projects/approval'
+                >
+                  Approve Projects
+                  {projectStats && projectStats.pendingProjects > 0 && (
+                    <span className="inline-flex items-center justify-center px-2 py-1 text-xs font-bold leading-none text-white bg-red-600 rounded-full">
+                      {projectStats.pendingProjects}
+                    </span>
+                  )}
+                </Link>
+              )}
             </div>
           </div>
 
-          <Tabs defaultValue="overview" className="space-y-6">
+          <Tabs defaultValue={defaultAdminTab} className="space-y-6">
             <TabsList className="grid h-auto w-full grid-cols-1 gap-3 bg-transparent p-0 sm:grid-cols-2 xl:grid-cols-5">
+              {canViewAdminOverview && (
               <TabsTrigger
                 value="overview"
                 className="group min-h-[88px] justify-start rounded-2xl border-0 bg-gradient-to-r from-fuchsia-500 via-pink-500 to-rose-500 px-5 py-4 text-left text-white shadow-md transition-all duration-200 hover:-translate-y-1 hover:shadow-xl data-[state=active]:ring-4 data-[state=active]:ring-fuchsia-200/70 data-[state=active]:shadow-fuchsia-200/80 data-[state=active]:shadow-2xl"
@@ -512,149 +551,170 @@ export default function DashboardPage() {
                   </div>
                 </div>
               </TabsTrigger>
-              <TabsTrigger
-                value="services"
-                className="group min-h-[88px] justify-start rounded-2xl border-0 bg-gradient-to-r from-violet-500 via-purple-500 to-fuchsia-500 px-5 py-4 text-left text-white shadow-md transition-all duration-200 hover:-translate-y-1 hover:shadow-xl data-[state=active]:ring-4 data-[state=active]:ring-violet-200/70 data-[state=active]:shadow-violet-200/80 data-[state=active]:shadow-2xl"
-              >
-                <div className="flex items-center gap-3">
-                  <div className="inline-flex rounded-xl bg-white/20 p-2.5 shadow-sm backdrop-blur-sm">
-                    <Package className="h-5 w-5 text-white" />
+              )}
+              {canManageServices && (
+                <TabsTrigger
+                  value="services"
+                  className="group min-h-[88px] justify-start rounded-2xl border-0 bg-gradient-to-r from-violet-500 via-purple-500 to-fuchsia-500 px-5 py-4 text-left text-white shadow-md transition-all duration-200 hover:-translate-y-1 hover:shadow-xl data-[state=active]:ring-4 data-[state=active]:ring-violet-200/70 data-[state=active]:shadow-violet-200/80 data-[state=active]:shadow-2xl"
+                >
+                  <div className="flex items-center gap-3">
+                    <div className="inline-flex rounded-xl bg-white/20 p-2.5 shadow-sm backdrop-blur-sm">
+                      <Package className="h-5 w-5 text-white" />
+                    </div>
+                    <div>
+                      <div className="font-semibold text-white">Services</div>
+                      <div className="mt-0.5 text-xs leading-5 text-white/85">Open service setup</div>
+                    </div>
                   </div>
-                  <div>
-                    <div className="font-semibold text-white">Services</div>
-                    <div className="mt-0.5 text-xs leading-5 text-white/85">Open service setup</div>
+                </TabsTrigger>
+              )}
+              {canManageLoyalty && (
+                <TabsTrigger
+                  value="loyalty"
+                  className="group min-h-[88px] justify-start rounded-2xl border-0 bg-gradient-to-r from-amber-400 via-orange-400 to-rose-400 px-5 py-4 text-left text-white shadow-md transition-all duration-200 hover:-translate-y-1 hover:shadow-xl data-[state=active]:ring-4 data-[state=active]:ring-amber-200/70 data-[state=active]:shadow-amber-200/80 data-[state=active]:shadow-2xl"
+                >
+                  <div className="flex items-center gap-3">
+                    <div className="inline-flex rounded-xl bg-white/20 p-2.5 shadow-sm backdrop-blur-sm">
+                      <Award className="h-5 w-5 text-white" />
+                    </div>
+                    <div>
+                      <div className="font-semibold text-white">Loyalty System</div>
+                      <div className="mt-0.5 text-xs leading-5 text-white/85">Open loyalty controls</div>
+                    </div>
                   </div>
-                </div>
-              </TabsTrigger>
-              <TabsTrigger
-                value="loyalty"
-                className="group min-h-[88px] justify-start rounded-2xl border-0 bg-gradient-to-r from-amber-400 via-orange-400 to-rose-400 px-5 py-4 text-left text-white shadow-md transition-all duration-200 hover:-translate-y-1 hover:shadow-xl data-[state=active]:ring-4 data-[state=active]:ring-amber-200/70 data-[state=active]:shadow-amber-200/80 data-[state=active]:shadow-2xl"
-              >
-                <div className="flex items-center gap-3">
-                  <div className="inline-flex rounded-xl bg-white/20 p-2.5 shadow-sm backdrop-blur-sm">
-                    <Award className="h-5 w-5 text-white" />
+                </TabsTrigger>
+              )}
+              {canApproveProfessionals && (
+                <TabsTrigger
+                  value="approvals"
+                  className="group min-h-[88px] justify-start rounded-2xl border-0 bg-gradient-to-r from-sky-500 via-cyan-500 to-blue-500 px-5 py-4 text-left text-white shadow-md transition-all duration-200 hover:-translate-y-1 hover:shadow-xl data-[state=active]:ring-4 data-[state=active]:ring-sky-200/70 data-[state=active]:shadow-sky-200/80 data-[state=active]:shadow-2xl"
+                >
+                  <div className="flex items-center gap-3">
+                    <div className="inline-flex rounded-xl bg-white/20 p-2.5 shadow-sm backdrop-blur-sm">
+                      <Users className="h-5 w-5 text-white" />
+                    </div>
+                    <div>
+                      <div className="font-semibold text-white">Professional Approvals</div>
+                      <div className="mt-0.5 text-xs leading-5 text-white/85">Open approval queues</div>
+                    </div>
                   </div>
-                  <div>
-                    <div className="font-semibold text-white">Loyalty System</div>
-                    <div className="mt-0.5 text-xs leading-5 text-white/85">Open loyalty controls</div>
+                </TabsTrigger>
+              )}
+              {canManagePayments && (
+                <TabsTrigger
+                  value="payments"
+                  className="group min-h-[88px] justify-start rounded-2xl border-0 bg-gradient-to-r from-emerald-500 via-teal-500 to-cyan-500 px-5 py-4 text-left text-white shadow-md transition-all duration-200 hover:-translate-y-1 hover:shadow-xl data-[state=active]:ring-4 data-[state=active]:ring-emerald-200/70 data-[state=active]:shadow-emerald-200/80 data-[state=active]:shadow-2xl"
+                >
+                  <div className="flex items-center gap-3">
+                    <div className="inline-flex rounded-xl bg-white/20 p-2.5 shadow-sm backdrop-blur-sm">
+                      <CreditCard className="h-5 w-5 text-white" />
+                    </div>
+                    <div>
+                      <div className="font-semibold text-white">Payments</div>
+                      <div className="mt-0.5 text-xs leading-5 text-white/85">Open payment oversight</div>
+                    </div>
                   </div>
-                </div>
-              </TabsTrigger>
-              <TabsTrigger
-                value="approvals"
-                className="group min-h-[88px] justify-start rounded-2xl border-0 bg-gradient-to-r from-sky-500 via-cyan-500 to-blue-500 px-5 py-4 text-left text-white shadow-md transition-all duration-200 hover:-translate-y-1 hover:shadow-xl data-[state=active]:ring-4 data-[state=active]:ring-sky-200/70 data-[state=active]:shadow-sky-200/80 data-[state=active]:shadow-2xl"
-              >
-                <div className="flex items-center gap-3">
-                  <div className="inline-flex rounded-xl bg-white/20 p-2.5 shadow-sm backdrop-blur-sm">
-                    <Users className="h-5 w-5 text-white" />
-                  </div>
-                  <div>
-                    <div className="font-semibold text-white">Professional Approvals</div>
-                    <div className="mt-0.5 text-xs leading-5 text-white/85">Open approval queues</div>
-                  </div>
-                </div>
-              </TabsTrigger>
-              <TabsTrigger
-                value="payments"
-                className="group min-h-[88px] justify-start rounded-2xl border-0 bg-gradient-to-r from-emerald-500 via-teal-500 to-cyan-500 px-5 py-4 text-left text-white shadow-md transition-all duration-200 hover:-translate-y-1 hover:shadow-xl data-[state=active]:ring-4 data-[state=active]:ring-emerald-200/70 data-[state=active]:shadow-emerald-200/80 data-[state=active]:shadow-2xl"
-              >
-                <div className="flex items-center gap-3">
-                  <div className="inline-flex rounded-xl bg-white/20 p-2.5 shadow-sm backdrop-blur-sm">
-                    <CreditCard className="h-5 w-5 text-white" />
-                  </div>
-                  <div>
-                    <div className="font-semibold text-white">Payments</div>
-                    <div className="mt-0.5 text-xs leading-5 text-white/85">Open payment oversight</div>
-                  </div>
-                </div>
-              </TabsTrigger>
+                </TabsTrigger>
+              )}
             </TabsList>
 
+            {canViewAdminOverview && (
             <TabsContent value="overview" className="space-y-6">
               <div className="grid md:grid-cols-2 lg:grid-cols-5 gap-6">
                 {/* Quick Stats */}
-                <Card
-                  className="cursor-pointer border-blue-100 bg-gradient-to-br from-white via-blue-50 to-indigo-100 shadow-md transition-all duration-200 hover:-translate-y-1 hover:shadow-xl"
-                  onClick={() => openAdmin('/admin/projects/approval')}
-                >
-                  <CardHeader className="pb-2">
-                    <CardTitle className="flex items-center gap-2 text-sm">
-                      <Briefcase className="h-4 w-4 text-blue-500" />
-                      Pending Projects
-                    </CardTitle>
-                  </CardHeader>
-                  <CardContent>
-                    <div className="text-2xl font-bold text-blue-600">
-                      {isLoadingStats ? '...' : projectStats?.pendingProjects || 0}
-                    </div>
-                    <p className="text-xs text-gray-500 mt-1">Click to review</p>
-                  </CardContent>
-                </Card>
+                {canApproveProjects && (
+                  <Card
+                    className="cursor-pointer border-blue-100 bg-gradient-to-br from-white via-blue-50 to-indigo-100 shadow-md transition-all duration-200 hover:-translate-y-1 hover:shadow-xl"
+                    onClick={() => openAdmin('/admin/projects/approval')}
+                  >
+                    <CardHeader className="pb-2">
+                      <CardTitle className="flex items-center gap-2 text-sm">
+                        <Briefcase className="h-4 w-4 text-blue-500" />
+                        Pending Projects
+                      </CardTitle>
+                    </CardHeader>
+                    <CardContent>
+                      <div className="text-2xl font-bold text-blue-600">
+                        {isLoadingStats ? '...' : projectStats?.pendingProjects || 0}
+                      </div>
+                      <p className="text-xs text-gray-500 mt-1">Click to review</p>
+                    </CardContent>
+                  </Card>
+                )}
 
-                <Card className="border-emerald-100 bg-gradient-to-br from-white via-emerald-50 to-teal-100 shadow-md transition-all duration-200 hover:-translate-y-1 hover:shadow-xl">
-                  <CardHeader className="pb-2">
-                    <CardTitle className="flex items-center gap-2 text-sm">
-                      <Users className="h-4 w-4 text-green-500" />
-                      Total Customers
-                    </CardTitle>
-                  </CardHeader>
-                  <CardContent>
-                    <div className="text-2xl font-bold">
-                      {isLoadingStats ? '...' : loyaltyStats?.overallStats.totalCustomers || 0}
-                    </div>
-                  </CardContent>
-                </Card>
+                {canManageLoyalty && (
+                  <>
+                    <Card className="border-emerald-100 bg-gradient-to-br from-white via-emerald-50 to-teal-100 shadow-md transition-all duration-200 hover:-translate-y-1 hover:shadow-xl">
+                      <CardHeader className="pb-2">
+                        <CardTitle className="flex items-center gap-2 text-sm">
+                          <Users className="h-4 w-4 text-green-500" />
+                          Total Customers
+                        </CardTitle>
+                      </CardHeader>
+                      <CardContent>
+                        <div className="text-2xl font-bold">
+                          {isLoadingStats ? '...' : loyaltyStats?.overallStats.totalCustomers || 0}
+                        </div>
+                      </CardContent>
+                    </Card>
 
-                <Card className="border-cyan-100 bg-gradient-to-br from-white via-cyan-50 to-sky-100 shadow-md transition-all duration-200 hover:-translate-y-1 hover:shadow-xl">
-                  <CardHeader className="pb-2">
-                    <CardTitle className="flex items-center gap-2 text-sm">
-                      <TrendingUp className="h-4 w-4 text-emerald-500" />
-                      Total Revenue
-                    </CardTitle>
-                  </CardHeader>
-                  <CardContent>
-                    <div className="text-2xl font-bold">
-                      ${isLoadingStats ? '...' : (loyaltyStats?.overallStats.totalRevenue || 0).toLocaleString()}
-                    </div>
-                  </CardContent>
-                </Card>
+                    <Card className="border-cyan-100 bg-gradient-to-br from-white via-cyan-50 to-sky-100 shadow-md transition-all duration-200 hover:-translate-y-1 hover:shadow-xl">
+                      <CardHeader className="pb-2">
+                        <CardTitle className="flex items-center gap-2 text-sm">
+                          <TrendingUp className="h-4 w-4 text-emerald-500" />
+                          Total Revenue
+                        </CardTitle>
+                      </CardHeader>
+                      <CardContent>
+                        <div className="text-2xl font-bold">
+                          ${isLoadingStats ? '...' : (loyaltyStats?.overallStats.totalRevenue || 0).toLocaleString()}
+                        </div>
+                      </CardContent>
+                    </Card>
+                  </>
+                )}
 
-                <Card className="border-amber-100 bg-gradient-to-br from-white via-amber-50 to-orange-100 shadow-md transition-all duration-200 hover:-translate-y-1 hover:shadow-xl">
-                  <CardHeader className="pb-2">
-                    <CardTitle className="flex items-center gap-2 text-sm">
-                      <Clock className="h-4 w-4 text-orange-500" />
-                      Pending Professionals
-                    </CardTitle>
-                  </CardHeader>
-                  <CardContent>
-                    <div className="text-2xl font-bold">
-                      {isLoadingStats ? '...' : approvalStats?.pending || 0}
-                    </div>
-                  </CardContent>
-                </Card>
+                {canApproveProfessionals && (
+                  <Card className="border-amber-100 bg-gradient-to-br from-white via-amber-50 to-orange-100 shadow-md transition-all duration-200 hover:-translate-y-1 hover:shadow-xl">
+                    <CardHeader className="pb-2">
+                      <CardTitle className="flex items-center gap-2 text-sm">
+                        <Clock className="h-4 w-4 text-orange-500" />
+                        Pending Professionals
+                      </CardTitle>
+                    </CardHeader>
+                    <CardContent>
+                      <div className="text-2xl font-bold">
+                        {isLoadingStats ? '...' : approvalStats?.pending || 0}
+                      </div>
+                    </CardContent>
+                  </Card>
+                )}
 
-                <Card
-                  className="cursor-pointer border-rose-100 bg-gradient-to-br from-white via-rose-50 to-orange-100 shadow-md transition-all duration-200 hover:-translate-y-1 hover:shadow-xl"
-                  onClick={() => openAdmin('/admin/warranty-claims')}
-                >
-                  <CardHeader className="pb-2">
-                    <CardTitle className="flex items-center gap-2 text-sm">
-                      <AlertTriangle className="h-4 w-4 text-rose-500" />
-                      Warranty Claims
-                    </CardTitle>
-                  </CardHeader>
-                  <CardContent>
-                    <div className="text-2xl font-bold text-rose-600">
-                      {isLoadingStats ? '...' : warrantyAnalytics?.summary?.totalClaims ?? '\u2014'}
-                    </div>
-                    <p className="text-xs text-gray-500 mt-1">
-                      Escalated: {isLoadingStats ? '...' : warrantyAnalytics?.summary?.totalEscalated ?? '\u2014'}
-                    </p>
-                  </CardContent>
-                </Card>
+                {canManageWarranty && (
+                  <Card
+                    className="cursor-pointer border-rose-100 bg-gradient-to-br from-white via-rose-50 to-orange-100 shadow-md transition-all duration-200 hover:-translate-y-1 hover:shadow-xl"
+                    onClick={() => openAdmin('/admin/warranty-claims')}
+                  >
+                    <CardHeader className="pb-2">
+                      <CardTitle className="flex items-center gap-2 text-sm">
+                        <AlertTriangle className="h-4 w-4 text-rose-500" />
+                        Warranty Claims
+                      </CardTitle>
+                    </CardHeader>
+                    <CardContent>
+                      <div className="text-2xl font-bold text-rose-600">
+                        {isLoadingStats ? '...' : warrantyAnalytics?.summary?.totalClaims ?? '\u2014'}
+                      </div>
+                      <p className="text-xs text-gray-500 mt-1">
+                        Escalated: {isLoadingStats ? '...' : warrantyAnalytics?.summary?.totalEscalated ?? '\u2014'}
+                      </p>
+                    </CardContent>
+                  </Card>
+                )}
               </div>
 
               <div className="grid md:grid-cols-2 xl:grid-cols-3 gap-6">
+              {canAccessPath('/admin/referral') && (
               <Card className="border-purple-100 bg-gradient-to-br from-white via-purple-50 to-fuchsia-100 shadow-md transition-all duration-200 hover:-translate-y-1 hover:shadow-xl">
                 <CardHeader>
                   <CardTitle className="flex items-center gap-2">
@@ -683,7 +743,9 @@ export default function DashboardPage() {
                   </Button>
                 </CardContent>
               </Card>
+              )}
 
+              {canAccessPath('/admin/backlinks') && (
               <Card className="border-indigo-100 bg-gradient-to-br from-white via-indigo-50 to-blue-100 shadow-md transition-all duration-200 hover:-translate-y-1 hover:shadow-xl">
                 <CardHeader>
                   <CardTitle className="flex items-center gap-2">
@@ -712,7 +774,9 @@ export default function DashboardPage() {
                   </Button>
                 </CardContent>
               </Card>
+              )}
 
+              {canAccessPath('/admin/reviews') && (
               <Card className="border-amber-100 bg-gradient-to-br from-white via-amber-50 to-rose-100 shadow-md transition-all duration-200 hover:-translate-y-1 hover:shadow-xl">
                 <CardHeader>
                   <CardTitle className="flex items-center gap-2">
@@ -744,7 +808,9 @@ export default function DashboardPage() {
                   </Button>
                 </CardContent>
               </Card>
+              )}
 
+              {canAccessPath('/admin/favorites') && (
               <Card className="border-pink-100 bg-gradient-to-br from-white via-pink-50 to-purple-100 shadow-md transition-all duration-200 hover:-translate-y-1 hover:shadow-xl">
                 <CardHeader>
                   <CardTitle className="flex items-center gap-2">
@@ -763,7 +829,9 @@ export default function DashboardPage() {
                   </Button>
                 </CardContent>
               </Card>
+              )}
 
+              {canAccessPath('/admin/settings') && (
               <Card className="border-slate-200 bg-gradient-to-br from-white via-slate-50 to-gray-100 shadow-md transition-all duration-200 hover:-translate-y-1 hover:shadow-xl">
                 <CardHeader>
                   <CardTitle className="flex items-center gap-2">
@@ -782,7 +850,9 @@ export default function DashboardPage() {
                   </Button>
                 </CardContent>
               </Card>
+              )}
 
+              {canAccessPath('/admin/cms') && (
               <Card className="border-rose-100 bg-gradient-to-br from-white via-rose-50 to-pink-100 shadow-md transition-all duration-200 hover:-translate-y-1 hover:shadow-xl">
                 <CardHeader>
                   <CardTitle className="flex items-center gap-2">
@@ -801,7 +871,9 @@ export default function DashboardPage() {
                   </Button>
                 </CardContent>
               </Card>
+              )}
 
+              {canAccessPath('/admin/support') && (
               <Card className="border-indigo-100 bg-gradient-to-br from-white via-indigo-50 to-blue-100 shadow-md transition-all duration-200 hover:-translate-y-1 hover:shadow-xl">
                 <CardHeader>
                   <CardTitle className="flex items-center gap-2">
@@ -820,7 +892,9 @@ export default function DashboardPage() {
                   </Button>
                 </CardContent>
               </Card>
+              )}
 
+              {canAccessPath('/admin/chat') && (
               <Card className="border-sky-100 bg-gradient-to-br from-white via-sky-50 to-indigo-100 shadow-md transition-all duration-200 hover:-translate-y-1 hover:shadow-xl">
                 <CardHeader>
                   <CardTitle className="flex items-center gap-2">
@@ -839,7 +913,9 @@ export default function DashboardPage() {
                   </Button>
                 </CardContent>
               </Card>
+              )}
 
+              {canAccessPath('/admin/discount-codes') && (
               <Card className="border-rose-100 bg-gradient-to-br from-white via-rose-50 to-orange-100 shadow-md transition-all duration-200 hover:-translate-y-1 hover:shadow-xl">
                 <CardHeader>
                   <CardTitle className="flex items-center gap-2">
@@ -858,7 +934,9 @@ export default function DashboardPage() {
                   </Button>
                 </CardContent>
               </Card>
+              )}
 
+              {canAccessPath('/admin/campaigns') && (
               <Card className="border-violet-100 bg-gradient-to-br from-white via-violet-50 to-fuchsia-100 shadow-md transition-all duration-200 hover:-translate-y-1 hover:shadow-xl">
                 <CardHeader>
                   <CardTitle className="flex items-center gap-2">
@@ -877,7 +955,9 @@ export default function DashboardPage() {
                   </Button>
                 </CardContent>
               </Card>
+              )}
 
+              {canAccessPath('/admin/site-announcements') && (
               <Card className="border-orange-100 bg-gradient-to-br from-white via-orange-50 to-amber-100 shadow-md transition-all duration-200 hover:-translate-y-1 hover:shadow-xl">
                 <CardHeader>
                   <CardTitle className="flex items-center gap-2">
@@ -896,7 +976,9 @@ export default function DashboardPage() {
                   </Button>
                 </CardContent>
               </Card>
+              )}
 
+              {canAccessPath('/admin/professionals/manage') && (
               <Card className="border-blue-100 bg-gradient-to-br from-white via-blue-50 to-cyan-100 shadow-md transition-all duration-200 hover:-translate-y-1 hover:shadow-xl">
                 <CardHeader>
                   <CardTitle className="flex items-center gap-2">
@@ -915,7 +997,9 @@ export default function DashboardPage() {
                   </Button>
                 </CardContent>
               </Card>
+              )}
 
+              {canAccessPath('/admin/customers') && (
               <Card className="border-emerald-100 bg-gradient-to-br from-white via-emerald-50 to-teal-100 shadow-md transition-all duration-200 hover:-translate-y-1 hover:shadow-xl">
                 <CardHeader>
                   <CardTitle className="flex items-center gap-2">
@@ -934,7 +1018,9 @@ export default function DashboardPage() {
                   </Button>
                 </CardContent>
               </Card>
+              )}
 
+              {canAccessPath('/admin/warranty-claims') && (
               <Card className="border-rose-100 bg-gradient-to-br from-white via-rose-50 to-orange-100 shadow-md transition-all duration-200 hover:-translate-y-1 hover:shadow-xl">
                 <CardHeader>
                   <CardTitle className="flex items-center gap-2">
@@ -968,14 +1054,20 @@ export default function DashboardPage() {
                   </Button>
                 </CardContent>
               </Card>
+              )}
 
+              {canAccessPath('/admin/bookings') && (
               <Card className="border-blue-100 bg-gradient-to-br from-white via-blue-50 to-indigo-100 shadow-md transition-all duration-200 hover:-translate-y-1 hover:shadow-xl">
                 <CardHeader>
                   <CardTitle className="flex items-center gap-2">
                     <Calendar className="h-5 w-5 text-blue-600" />
                     Booking Management
                   </CardTitle>
-                  <CardDescription>Browse and search any booking, force its status, and open a chat with the customer or professional</CardDescription>
+                  <CardDescription>
+                    Browse and search bookings
+                    {can('bookings.write') ? ', update their status' : ''}
+                    {can('chat.support') ? ', and open customer or professional support chats' : ''}
+                  </CardDescription>
                 </CardHeader>
                 <CardContent>
                   <Button
@@ -986,7 +1078,9 @@ export default function DashboardPage() {
                   </Button>
                 </CardContent>
               </Card>
+              )}
 
+              {canAccessPath('/admin/disputes') && (
               <Card className="border-red-100 bg-gradient-to-br from-white via-red-50 to-amber-100 shadow-md transition-all duration-200 hover:-translate-y-1 hover:shadow-xl">
                 <CardHeader>
                   <CardTitle className="flex items-center gap-2">
@@ -1004,7 +1098,9 @@ export default function DashboardPage() {
                   </Button>
                 </CardContent>
               </Card>
+              )}
 
+              {canAccessPath('/admin/cancellation-requests') && (
               <Card className="border-amber-100 bg-gradient-to-br from-white via-amber-50 to-orange-100 shadow-md transition-all duration-200 hover:-translate-y-1 hover:shadow-xl">
                 <CardHeader>
                   <CardTitle className="flex items-center gap-2">
@@ -1022,7 +1118,9 @@ export default function DashboardPage() {
                   </Button>
                 </CardContent>
               </Card>
+              )}
 
+              {canAccessPath('/admin/chat-reports') && (
               <Card className="border-purple-100 bg-gradient-to-br from-white via-purple-50 to-pink-100 shadow-md transition-all duration-200 hover:-translate-y-1 hover:shadow-xl">
                 <CardHeader>
                   <CardTitle className="flex items-center gap-2">
@@ -1040,7 +1138,9 @@ export default function DashboardPage() {
                   </Button>
                 </CardContent>
               </Card>
+              )}
 
+              {canAccessPath('/admin/audit-logs') && (
               <Card className="border-slate-200 bg-gradient-to-br from-white via-slate-50 to-zinc-100 shadow-md transition-all duration-200 hover:-translate-y-1 hover:shadow-xl">
                 <CardHeader>
                   <CardTitle className="flex items-center gap-2">
@@ -1058,7 +1158,9 @@ export default function DashboardPage() {
                   </Button>
                 </CardContent>
               </Card>
+              )}
 
+              {canRunMaintenance && (
               <Card className="border-indigo-100 bg-gradient-to-br from-white via-indigo-50 to-blue-100 shadow-md transition-all duration-200 hover:-translate-y-1 hover:shadow-xl xl:col-span-2">
                 <CardHeader>
                   <CardTitle className="flex items-center gap-2">
@@ -1186,9 +1288,12 @@ export default function DashboardPage() {
                   </div>
                 </CardContent>
               </Card>
+              )}
               </div>
             </TabsContent>
+            )}
 
+            {canManageServices && (
             <TabsContent value="services" className="space-y-6">
               {/* Service Configuration Management */}
               <Card className="border-purple-100 bg-gradient-to-br from-white via-purple-50 to-pink-100 shadow-md transition-all duration-200 hover:-translate-y-1 hover:shadow-xl">
@@ -1234,7 +1339,9 @@ export default function DashboardPage() {
                 </CardContent>
               </Card>
             </TabsContent>
+            )}
 
+            {canManageLoyalty && (
             <TabsContent value="loyalty" className="space-y-6">
               {/* Loyalty System Management */}
               <div className="grid md:grid-cols-3 gap-6">
@@ -1350,7 +1457,9 @@ export default function DashboardPage() {
                 </Card>
               </div>
             </TabsContent>
+            )}
 
+            {canApproveProfessionals && (
             <TabsContent value="approvals" className="space-y-6">
               {/* Professional Approvals */}
               <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-6">
@@ -1447,7 +1556,9 @@ export default function DashboardPage() {
                 </CardContent>
               </Card>
             </TabsContent>
+            )}
 
+            {canManagePayments && (
             <TabsContent value="payments" className="space-y-6">
               {/* Payment Oversight */}
               <Card className="border-blue-100 bg-gradient-to-br from-white via-blue-50 to-indigo-100 shadow-md transition-all duration-200 hover:-translate-y-1 hover:shadow-xl">
@@ -1494,6 +1605,7 @@ export default function DashboardPage() {
                 </CardContent>
               </Card>
             </TabsContent>
+            )}
 
           </Tabs>
         </div>

--- a/app/(pages)/dashboard/page.tsx
+++ b/app/(pages)/dashboard/page.tsx
@@ -840,6 +840,25 @@ export default function DashboardPage() {
                 </CardContent>
               </Card>
 
+              <Card className="border-violet-100 bg-gradient-to-br from-white via-violet-50 to-fuchsia-100 shadow-md transition-all duration-200 hover:-translate-y-1 hover:shadow-xl">
+                <CardHeader>
+                  <CardTitle className="flex items-center gap-2">
+                    <Mail className="h-5 w-5 text-violet-500" />
+                    Email Campaigns
+                  </CardTitle>
+                  <CardDescription>Brevo newsletters, promos, and re-engagement by region/service</CardDescription>
+                </CardHeader>
+                <CardContent>
+                  <Button
+                    onClick={() => openAdmin('/admin/campaigns')}
+                    className="w-full bg-gradient-to-r from-violet-500 to-fuchsia-500 hover:from-violet-600 hover:to-fuchsia-600"
+                  >
+                    <Mail className="h-4 w-4 mr-2" />
+                    Manage Campaigns
+                  </Button>
+                </CardContent>
+              </Card>
+
               <Card className="border-orange-100 bg-gradient-to-br from-white via-orange-50 to-amber-100 shadow-md transition-all duration-200 hover:-translate-y-1 hover:shadow-xl">
                 <CardHeader>
                   <CardTitle className="flex items-center gap-2">

--- a/app/(pages)/projects/[id]/page.tsx
+++ b/app/(pages)/projects/[id]/page.tsx
@@ -33,6 +33,7 @@ import {
   X,
 } from 'lucide-react';
 import { toast } from 'sonner';
+import { authFetch } from '@/lib/utils';
 import Link from 'next/link';
 import { Skeleton } from "@/components/ui/skeleton";
 import { Input } from "@/components/ui/input";
@@ -343,7 +344,6 @@ export default function ProjectDetailPage() {
     let cancelled = false;
     (async () => {
       try {
-        const { authFetch } = await import('@/lib/utils');
         const res = await authFetch(
           `${process.env.NEXT_PUBLIC_BACKEND_URL}/api/favorites/status`,
           {

--- a/app/(pages)/unsubscribe/page.tsx
+++ b/app/(pages)/unsubscribe/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Suspense, useState } from "react";
+import { Suspense, useEffect, useRef, useState } from "react";
 import { useSearchParams } from "next/navigation";
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
@@ -22,6 +22,18 @@ function UnsubscribeInner() {
 
   const [status, setStatus] = useState<"idle" | "loading" | "done" | "error">("idle");
   const [message, setMessage] = useState("");
+  const requestRef = useRef<AbortController | null>(null);
+  const paramsKey = `${token}:${email}:${subscriberToken}`;
+  const paramsKeyRef = useRef(paramsKey);
+
+  useEffect(() => {
+    paramsKeyRef.current = paramsKey;
+    requestRef.current?.abort();
+    requestRef.current = null;
+    setStatus("idle");
+    setMessage("");
+    return () => requestRef.current?.abort();
+  }, [paramsKey]);
 
   const runUnsubscribe = async () => {
     if (!API_BASE) {
@@ -29,22 +41,36 @@ function UnsubscribeInner() {
       setStatus("error");
       return;
     }
+    requestRef.current?.abort();
+    const controller = new AbortController();
+    requestRef.current = controller;
+    const requestParamsKey = paramsKey;
+    const timeout = window.setTimeout(() => controller.abort(), 15_000);
     setStatus("loading");
     try {
       const res = await fetch(`${API_BASE}/api/public/marketing/unsubscribe`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ token, email, subscriberToken }),
+        signal: controller.signal,
       });
       const json = await res.json().catch(() => null);
       if (!res.ok || !json?.success) {
         throw new Error(json?.msg || "Unsubscribe failed");
       }
-      setMessage(json.data?.message || "You have been unsubscribed.");
-      setStatus("done");
+      if (requestParamsKey === paramsKeyRef.current) {
+        setMessage(json.data?.message || "You have been unsubscribed.");
+        setStatus("done");
+      }
     } catch (e: unknown) {
-      setMessage(errMessage(e, "Unsubscribe failed"));
-      setStatus("error");
+      if (requestParamsKey === paramsKeyRef.current) {
+        const aborted = e instanceof DOMException && e.name === "AbortError";
+        setMessage(aborted ? "The request timed out. Please try again." : errMessage(e, "Unsubscribe failed"));
+        setStatus("error");
+      }
+    } finally {
+      window.clearTimeout(timeout);
+      if (requestRef.current === controller) requestRef.current = null;
     }
   };
 

--- a/app/(pages)/unsubscribe/page.tsx
+++ b/app/(pages)/unsubscribe/page.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+import { Suspense, useEffect, useState } from "react";
+import { useSearchParams } from "next/navigation";
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Loader2 } from "lucide-react";
+
+const API_BASE = process.env.NEXT_PUBLIC_BACKEND_URL || "http://localhost:4000";
+
+function UnsubscribeInner() {
+  const searchParams = useSearchParams();
+  const token = searchParams.get("token") || "";
+  const email = searchParams.get("email") || "";
+  const subscriberToken = searchParams.get("subscriberToken") || "";
+
+  const [status, setStatus] = useState<"idle" | "loading" | "done" | "error">("idle");
+  const [message, setMessage] = useState("");
+
+  const runUnsubscribe = async () => {
+    setStatus("loading");
+    try {
+      const res = await fetch(`${API_BASE}/api/public/marketing/unsubscribe`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ token, email, subscriberToken }),
+      });
+      const json = await res.json();
+      if (!res.ok || !json.success) throw new Error(json.msg || "Unsubscribe failed");
+      setMessage(json.data?.message || "You have been unsubscribed.");
+      setStatus("done");
+    } catch (e: any) {
+      setMessage(e.message || "Unsubscribe failed");
+      setStatus("error");
+    }
+  };
+
+  useEffect(() => {
+    if (token || (email && subscriberToken)) {
+      void runUnsubscribe();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return (
+    <Card className="w-full max-w-md">
+      <CardHeader>
+        <CardTitle>Email preferences</CardTitle>
+        <CardDescription>Manage Fixtract promotional email subscription</CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {status === "idle" && !token && !(email && subscriberToken) && (
+          <>
+            <p className="text-sm text-muted-foreground">
+              Open the unsubscribe link from a campaign email, or manage preferences in your
+              profile.
+            </p>
+            <Button asChild>
+              <Link href="/profile?tab=notifications">Open notification settings</Link>
+            </Button>
+          </>
+        )}
+        {status === "loading" && (
+          <div className="flex items-center gap-2 text-sm text-muted-foreground">
+            <Loader2 className="h-4 w-4 animate-spin" />
+            Unsubscribing…
+          </div>
+        )}
+        {status === "done" && <p className="text-sm text-emerald-700">{message}</p>}
+        {status === "error" && (
+          <div className="space-y-3">
+            <p className="text-sm text-rose-600">{message}</p>
+            <Button variant="outline" onClick={runUnsubscribe}>
+              Try again
+            </Button>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+export default function UnsubscribePage() {
+  return (
+    <div className="min-h-[60vh] flex items-center justify-center p-6">
+      <Suspense fallback={<Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />}>
+        <UnsubscribeInner />
+      </Suspense>
+    </div>
+  );
+}

--- a/app/(pages)/unsubscribe/page.tsx
+++ b/app/(pages)/unsubscribe/page.tsx
@@ -36,6 +36,7 @@ function UnsubscribeInner() {
   }, [paramsKey]);
 
   const runUnsubscribe = async () => {
+    if (status === "loading") return;
     if (!API_BASE) {
       setMessage("Server URL is not configured");
       setStatus("error");

--- a/app/(pages)/unsubscribe/page.tsx
+++ b/app/(pages)/unsubscribe/page.tsx
@@ -1,24 +1,34 @@
 "use client";
 
-import { Suspense, useEffect, useState } from "react";
+import { Suspense, useState } from "react";
 import { useSearchParams } from "next/navigation";
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Loader2 } from "lucide-react";
 
-const API_BASE = process.env.NEXT_PUBLIC_BACKEND_URL || "http://localhost:4000";
+const API_BASE = process.env.NEXT_PUBLIC_BACKEND_URL || "";
+
+function errMessage(e: unknown, fallback: string): string {
+  return e instanceof Error && e.message ? e.message : fallback;
+}
 
 function UnsubscribeInner() {
   const searchParams = useSearchParams();
   const token = searchParams.get("token") || "";
   const email = searchParams.get("email") || "";
   const subscriberToken = searchParams.get("subscriberToken") || "";
+  const hasParams = Boolean(token || (email && subscriberToken));
 
   const [status, setStatus] = useState<"idle" | "loading" | "done" | "error">("idle");
   const [message, setMessage] = useState("");
 
   const runUnsubscribe = async () => {
+    if (!API_BASE) {
+      setMessage("Server URL is not configured");
+      setStatus("error");
+      return;
+    }
     setStatus("loading");
     try {
       const res = await fetch(`${API_BASE}/api/public/marketing/unsubscribe`, {
@@ -26,22 +36,17 @@ function UnsubscribeInner() {
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ token, email, subscriberToken }),
       });
-      const json = await res.json();
-      if (!res.ok || !json.success) throw new Error(json.msg || "Unsubscribe failed");
+      const json = await res.json().catch(() => null);
+      if (!res.ok || !json?.success) {
+        throw new Error(json?.msg || "Unsubscribe failed");
+      }
       setMessage(json.data?.message || "You have been unsubscribed.");
       setStatus("done");
-    } catch (e: any) {
-      setMessage(e.message || "Unsubscribe failed");
+    } catch (e: unknown) {
+      setMessage(errMessage(e, "Unsubscribe failed"));
       setStatus("error");
     }
   };
-
-  useEffect(() => {
-    if (token || (email && subscriberToken)) {
-      void runUnsubscribe();
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
 
   return (
     <Card className="w-full max-w-md">
@@ -50,7 +55,7 @@ function UnsubscribeInner() {
         <CardDescription>Manage Fixtract promotional email subscription</CardDescription>
       </CardHeader>
       <CardContent className="space-y-4">
-        {status === "idle" && !token && !(email && subscriberToken) && (
+        {status === "idle" && !hasParams && (
           <>
             <p className="text-sm text-muted-foreground">
               Open the unsubscribe link from a campaign email, or manage preferences in your
@@ -59,6 +64,15 @@ function UnsubscribeInner() {
             <Button asChild>
               <Link href="/profile?tab=notifications">Open notification settings</Link>
             </Button>
+          </>
+        )}
+        {status === "idle" && hasParams && (
+          <>
+            <p className="text-sm text-muted-foreground">
+              Confirm to stop receiving Fixtract promotional emails. Transactional booking emails
+              are unaffected.
+            </p>
+            <Button onClick={runUnsubscribe}>Unsubscribe from promotions</Button>
           </>
         )}
         {status === "loading" && (

--- a/components/admin/site-announcements/AnnouncementsCard.tsx
+++ b/components/admin/site-announcements/AnnouncementsCard.tsx
@@ -27,6 +27,9 @@ import {
 
 interface AnnouncementsCardProps {
   items: AdminSiteAnnouncement[];
+  page: number;
+  total: number;
+  onPageChange: (page: number) => void;
   loading: boolean;
   filters: AnnouncementListFilters;
   onFiltersChange: (partial: Partial<AnnouncementListFilters>) => void;
@@ -38,6 +41,9 @@ interface AnnouncementsCardProps {
 
 export function AnnouncementsCard({
   items,
+  page,
+  total,
+  onPageChange,
   loading,
   filters,
   onFiltersChange,
@@ -51,7 +57,7 @@ export function AnnouncementsCard({
       <CardHeader className="space-y-4">
         <div>
           <CardTitle>Announcements</CardTitle>
-          <CardDescription>{items.length} result(s)</CardDescription>
+          <CardDescription>{total} result(s)</CardDescription>
         </div>
         <div className="grid w-full grid-cols-1 gap-3 sm:grid-cols-[minmax(0,1fr)_11rem_11rem]">
           <Input
@@ -170,6 +176,33 @@ export function AnnouncementsCard({
               );
             })}
           </ul>
+        )}
+        {!loading && (total > 20 || page > 1) && (
+          <div className="flex items-center justify-between border-t pt-3">
+            <Button
+              type="button"
+              size="sm"
+              variant="outline"
+              disabled={page <= 1}
+              onClick={() => onPageChange(Math.max(1, page - 1))}
+            >
+              Previous
+            </Button>
+            <span className="text-sm text-slate-500">
+              Page {page} of {Math.max(1, Math.ceil(total / 20))}
+            </span>
+            <Button
+              type="button"
+              size="sm"
+              variant="outline"
+              disabled={page >= Math.max(1, Math.ceil(total / 20))}
+              onClick={() =>
+                onPageChange(Math.min(Math.max(1, Math.ceil(total / 20)), page + 1))
+              }
+            >
+              Next
+            </Button>
+          </div>
         )}
       </CardContent>
     </Card>

--- a/components/cms/CmsContentForm.tsx
+++ b/components/cms/CmsContentForm.tsx
@@ -193,7 +193,10 @@ export default function CmsContentForm({ mode, initial, lockedType, initialSlug,
         body: form.body || "",
         excerpt: form.excerpt || "",
         coverImage: form.coverImage || undefined,
-        coverImageAlt: (form.coverImageAlt || "").trim() || undefined,
+        coverImageAlt:
+          mode === "edit"
+            ? (form.coverImageAlt || "").trim() || null
+            : (form.coverImageAlt || "").trim() || undefined,
         category: isFaq ? form.category : undefined,
         tags: hasTags ? form.tags || [] : [],
         authorOverride: hasTags ? (form.authorOverride || "").trim() : undefined,

--- a/components/marketing/site-announcements/PromoOverlay.tsx
+++ b/components/marketing/site-announcements/PromoOverlay.tsx
@@ -46,9 +46,9 @@ export function PromoOverlay({
       window.setTimeout(() => setCopied(false), 2000);
     } catch {
       toast.error("Could not copy code");
-      // The code remains visible, so a non-dismissible offer still needs an
-      // acknowledgement path when the Clipboard API is unavailable.
-      if (!canDismiss) onCta();
+      // Failed copy must not count as a CTA click for analytics; still acknowledge
+      // non-dismissible offers so the overlay can clear.
+      if (!canDismiss) onClose();
     }
   };
 

--- a/components/marketing/site-announcements/PromoOverlay.tsx
+++ b/components/marketing/site-announcements/PromoOverlay.tsx
@@ -46,6 +46,9 @@ export function PromoOverlay({
       window.setTimeout(() => setCopied(false), 2000);
     } catch {
       toast.error("Could not copy code");
+      // The code remains visible, so a non-dismissible offer still needs an
+      // acknowledgement path when the Clipboard API is unavailable.
+      if (!canDismiss) onCta();
     }
   };
 

--- a/components/marketing/site-announcements/PromoOverlay.tsx
+++ b/components/marketing/site-announcements/PromoOverlay.tsx
@@ -42,6 +42,7 @@ export function PromoOverlay({
       await navigator.clipboard.writeText(announcement.discountCode);
       setCopied(true);
       toast.success("Code copied");
+      if (!canDismiss) onCta();
       window.setTimeout(() => setCopied(false), 2000);
     } catch {
       toast.error("Could not copy code");

--- a/components/marketing/site-announcements/Provider.tsx
+++ b/components/marketing/site-announcements/Provider.tsx
@@ -75,6 +75,7 @@ export function SiteAnnouncementsProvider({ children }: { children: ReactNode })
   useEffect(() => {
     if (skip) return;
 
+    setClock(Date.now());
     const controller = new AbortController();
     let loading = false;
     const refresh = async () => {

--- a/components/marketing/site-announcements/Provider.tsx
+++ b/components/marketing/site-announcements/Provider.tsx
@@ -34,6 +34,7 @@ export function SiteAnnouncementsProvider({ children }: { children: ReactNode })
   const [consent, setConsent] = useState({ marketingOk: false, analyticsOk: false });
   const [hiddenIds, setHiddenIds] = useState<ReadonlySet<string>>(() => new Set());
   const [preview, setPreview] = useState<SiteAnnouncement | null>(null);
+  const [clock, setClock] = useState(() => Date.now());
   const previewTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
 
   const clearPreview = useCallback(() => {
@@ -75,7 +76,10 @@ export function SiteAnnouncementsProvider({ children }: { children: ReactNode })
     if (skip) return;
 
     const controller = new AbortController();
-    void (async () => {
+    let loading = false;
+    const refresh = async () => {
+      if (loading) return;
+      loading = true;
       try {
         const announcements = await fetchPublicSiteAnnouncements({
           signal: controller.signal,
@@ -85,29 +89,54 @@ export function SiteAnnouncementsProvider({ children }: { children: ReactNode })
         if (controller.signal.aborted) return;
         if (err instanceof DOMException && err.name === "AbortError") return;
         console.warn("[site-announcements] fetch failed", err);
+      } finally {
+        loading = false;
       }
-    })();
+    };
+    void refresh();
+    const refreshTimer = window.setInterval(() => void refresh(), 5 * 60 * 1000);
+    const clockTimer = window.setInterval(() => setClock(Date.now()), 60 * 1000);
 
-    return () => controller.abort();
+    return () => {
+      controller.abort();
+      window.clearInterval(refreshTimer);
+      window.clearInterval(clockTimer);
+    };
   }, [skip]);
 
   const hide = useCallback((announcement: SiteAnnouncement) => {
-    if (announcement.dismissible) dismissAnnouncement(announcement._id);
-    setHiddenIds((prev) => new Set(prev).add(announcement._id));
+    if (announcement.dismissible) dismissAnnouncement(announcement);
+    setHiddenIds((prev) =>
+      new Set(prev).add(`${announcement._id}:${announcement.updatedAt}`),
+    );
   }, []);
 
   const onCta = useCallback(
     (announcement: SiteAnnouncement) => {
+      hide(announcement);
       if (consent.analyticsOk) trackPromoClick(announcement);
     },
-    [consent.analyticsOk],
+    [consent.analyticsOk, hide],
   );
 
   const announcementsValue = useMemo<AnnouncementsCtx>(() => {
     const visible = skip
       ? []
       : items.filter((item) => {
-          if (hiddenIds.has(item._id) || isAnnouncementDismissed(item._id)) {
+          const startsAt = new Date(item.startsAt).getTime();
+          const endsAt = new Date(item.endsAt).getTime();
+          if (
+            !Number.isFinite(startsAt) ||
+            !Number.isFinite(endsAt) ||
+            startsAt > clock ||
+            endsAt < clock
+          ) {
+            return false;
+          }
+          if (
+            hiddenIds.has(`${item._id}:${item.updatedAt}`) ||
+            isAnnouncementDismissed(item)
+          ) {
             return false;
           }
           if (item.requireMarketingConsent && !consent.marketingOk) {
@@ -124,7 +153,7 @@ export function SiteAnnouncementsProvider({ children }: { children: ReactNode })
       hide,
       onCta,
     };
-  }, [skip, consent.marketingOk, items, hiddenIds, hide, onCta]);
+  }, [skip, consent.marketingOk, items, hiddenIds, hide, onCta, clock]);
 
   const previewValue = useMemo<PreviewCtx>(
     () => ({ preview, startPreview, clearPreview }),

--- a/components/marketing/site-announcements/Provider.tsx
+++ b/components/marketing/site-announcements/Provider.tsx
@@ -76,11 +76,14 @@ export function SiteAnnouncementsProvider({ children }: { children: ReactNode })
     if (skip) return;
 
     setClock(Date.now());
-    const controller = new AbortController();
+    let activeController: AbortController | null = null;
     let loading = false;
     const refresh = async () => {
-      if (loading) return;
+      if (loading || document.visibilityState === "hidden") return;
       loading = true;
+      const controller = new AbortController();
+      activeController = controller;
+      const timeout = window.setTimeout(() => controller.abort(), 15_000);
       try {
         const announcements = await fetchPublicSiteAnnouncements({
           signal: controller.signal,
@@ -91,15 +94,22 @@ export function SiteAnnouncementsProvider({ children }: { children: ReactNode })
         if (err instanceof DOMException && err.name === "AbortError") return;
         console.warn("[site-announcements] fetch failed", err);
       } finally {
+        window.clearTimeout(timeout);
+        if (activeController === controller) activeController = null;
         loading = false;
       }
     };
     void refresh();
     const refreshTimer = window.setInterval(() => void refresh(), 5 * 60 * 1000);
+    const refreshOnVisibility = () => {
+      if (document.visibilityState === "visible") void refresh();
+    };
+    document.addEventListener("visibilitychange", refreshOnVisibility);
     const clockTimer = window.setInterval(() => setClock(Date.now()), 60 * 1000);
 
     return () => {
-      controller.abort();
+      activeController?.abort();
+      document.removeEventListener("visibilitychange", refreshOnVisibility);
       window.clearInterval(refreshTimer);
       window.clearInterval(clockTimer);
     };

--- a/components/notifications/NotificationPreferences.tsx
+++ b/components/notifications/NotificationPreferences.tsx
@@ -28,7 +28,7 @@ interface Preferences {
 const DEFAULT_PREFS: Preferences = {
   booking_updates: { push: true, email: true },
   messages: { push: true, email: true },
-  promotions: { push: false, email: true },
+  promotions: { push: false, email: false },
   system: { push: true, email: true },
 };
 
@@ -76,7 +76,13 @@ async function fetchPrefs(): Promise<Preferences | null> {
   });
   if (!res.ok) return null;
   const json = await res.json();
-  return { ...DEFAULT_PREFS, ...(json.data ?? {}) };
+  const data = json.data ?? {};
+  return {
+    booking_updates: { ...DEFAULT_PREFS.booking_updates, ...data.booking_updates },
+    messages: { ...DEFAULT_PREFS.messages, ...data.messages },
+    promotions: { ...DEFAULT_PREFS.promotions, ...data.promotions },
+    system: { ...DEFAULT_PREFS.system, ...data.system },
+  };
 }
 
 async function patchPref(type: NotificationType, channel: Channel, enabled: boolean): Promise<boolean> {

--- a/contexts/AuthContext.tsx
+++ b/contexts/AuthContext.tsx
@@ -144,7 +144,7 @@ interface AuthContextType {
   login: (email: string, password: string, options?: { skipRedirect?: boolean }) => Promise<boolean>
   signup: (userData: SignupData) => Promise<boolean>
   logout: () => Promise<void>
-  checkAuth: () => Promise<User | null>
+  checkAuth: (options?: { strict?: boolean }) => Promise<User | null>
   isAuthenticated: boolean
 }
 
@@ -354,7 +354,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
     }
   }
 
-  const checkAuth = async (): Promise<User | null> => {
+  const checkAuth = async (options?: { strict?: boolean }): Promise<User | null> => {
     try {
       let result = await fetchCurrentUser()
 
@@ -374,7 +374,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
         return null
       }
 
-      return userRef.current
+      return options?.strict ? null : userRef.current
     } finally {
       setLoading(false)
     }

--- a/contexts/AuthContext.tsx
+++ b/contexts/AuthContext.tsx
@@ -489,6 +489,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
 
   // Middleware-like logic for route protection
   const handleRouteProtection = async (currentUser: User | null) => {
+    if (isAuthRoute(pathname)) return
     const isUserAuthenticated = !!currentUser
 
     // Check if this is a role-restricted route
@@ -543,7 +544,9 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
 
       const allowedRoles = getAllowedRoles(pathname)
       const isRoleRestrictedRoute = allowedRoles.length > 0
-      const needsProtection = isRoleRestrictedRoute || isProtectedRoute(pathname) || !isPublicRoute(pathname)
+      const needsProtection =
+        !isAuthRoute(pathname) &&
+        (isRoleRestrictedRoute || isProtectedRoute(pathname) || !isPublicRoute(pathname))
       if (needsProtection) {
         await handleRouteProtection(currentUser)
       }
@@ -679,4 +682,3 @@ export const AuthLoadingScreen: React.FC = () => (
     </div>
   </div>
 )
-

--- a/contexts/AuthContext.tsx
+++ b/contexts/AuthContext.tsx
@@ -315,6 +315,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
   const [loading, setLoading] = useState(true)
   const [isInitialized, setIsInitialized] = useState(false)
   const userRef = useRef<User | null>(null)
+  const checkAuthGenerationRef = useRef(0)
   const idExpiryAlertRef = useRef<string | null>(null)
   const idExpiryToastRef = useRef<string | number | null>(null)
   const router = useRouter()
@@ -355,12 +356,22 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
   }
 
   const checkAuth = async (options?: { strict?: boolean }): Promise<User | null> => {
+    const generation = ++checkAuthGenerationRef.current
     try {
       let result = await fetchCurrentUser()
 
       if (result.status === 'transient') {
         await new Promise(resolve => setTimeout(resolve, 600))
+        // Bail if a newer checkAuth started while we waited.
+        if (generation !== checkAuthGenerationRef.current) {
+          return options?.strict ? null : userRef.current
+        }
         result = await fetchCurrentUser()
+      }
+
+      // Superseded checks must not clear or overwrite a newer session.
+      if (generation !== checkAuthGenerationRef.current) {
+        return options?.strict ? null : userRef.current
       }
 
       if (result.status === 'ok') {
@@ -376,7 +387,9 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
 
       return options?.strict ? null : userRef.current
     } finally {
-      setLoading(false)
+      if (generation === checkAuthGenerationRef.current) {
+        setLoading(false)
+      }
     }
   }
 
@@ -538,6 +551,14 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
     let cancelled = false
 
     const initializeAuth = async () => {
+      // Invite acceptance stores a fresh token then runs a strict checkAuth.
+      // Skip the boot-time /me probe so a pre-token 401 cannot race and clear it.
+      if (pathname.startsWith('/admin/accept-invite')) {
+        setLoading(false)
+        if (!cancelled) setIsInitialized(true)
+        return
+      }
+
       const currentUser = await checkAuth()
 
       if (cancelled) return

--- a/hooks/useAdminUnreadCount.ts
+++ b/hooks/useAdminUnreadCount.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { useAuth } from "@/contexts/AuthContext";
 import { useChatPolling } from "@/hooks/useChatPolling";
 import { authFetch } from "@/lib/utils";
+import { useAdminAccess } from "@/hooks/useAdminAccess";
 import {
   getMigratedItem,
   migratePrefixedItems,
@@ -94,9 +95,11 @@ export const markAdminConversationSeen = (
 
 export const useAdminUnreadCount = () => {
   const { user, isAuthenticated } = useAuth();
+  const { can } = useAdminAccess();
   const [unreadCount, setUnreadCount] = useState(0);
 
-  const enabled = isAuthenticated && user?.role === "admin";
+  const enabled =
+    isAuthenticated && user?.role === "admin" && can("chat.support");
   const consecutiveFailuresRef = useRef(0);
   const cooldownUntilRef = useRef(0);
 

--- a/hooks/useSiteAnnouncementsAdmin.ts
+++ b/hooks/useSiteAnnouncementsAdmin.ts
@@ -37,6 +37,8 @@ export function useSiteAnnouncementsAdmin() {
 
   const [filters, setFilters] = useState<AnnouncementListFilters>(DEFAULT_FILTERS);
   const [items, setItems] = useState<AdminSiteAnnouncement[]>([]);
+  const [page, setPage] = useState(1);
+  const [total, setTotal] = useState(0);
   const [listLoading, setListLoading] = useState(true);
   const [reloadKey, setReloadKey] = useState(0);
   const [editor, setEditor] = useState<AnnouncementEditor>(null);
@@ -61,11 +63,17 @@ export function useSiteAnnouncementsAdmin() {
     const timer = window.setTimeout(async () => {
       setListLoading(true);
       try {
-        const announcements = await fetchSiteAnnouncements(filters, {
+        const result = await fetchSiteAnnouncements(filters, page, {
           signal: controller.signal,
         });
         if (!controller.signal.aborted) {
-          setItems(announcements);
+          setTotal(result.total);
+          const lastPage = Math.max(1, Math.ceil(result.total / 20));
+          if (page > lastPage) {
+            setPage(lastPage);
+            return;
+          }
+          setItems(result.items);
         }
       } catch (err) {
         if (controller.signal.aborted) return;
@@ -82,9 +90,10 @@ export function useSiteAnnouncementsAdmin() {
       window.clearTimeout(timer);
       controller.abort();
     };
-  }, [showPage, filters, reloadKey]);
+  }, [showPage, filters, page, reloadKey]);
 
   const patchFilters = (partial: Partial<AnnouncementListFilters>) => {
+    setPage(1);
     setFilters((prev) => ({ ...prev, ...partial }));
   };
 
@@ -157,6 +166,9 @@ export function useSiteAnnouncementsAdmin() {
     filters,
     patchFilters,
     items,
+    page,
+    total,
+    setPage,
     listLoading,
     editor,
     openCreate,

--- a/lib/admin/siteAnnouncements.ts
+++ b/lib/admin/siteAnnouncements.ts
@@ -115,8 +115,6 @@ export function toAnnouncementScheduleIso(value: string, isEnd: boolean): string
 const API_BASE = process.env.NEXT_PUBLIC_BACKEND_URL || "http://localhost:4000";
 
 export type AdminSiteAnnouncement = LiveSiteAnnouncement & {
-  startsAt: string;
-  endsAt: string;
   isActive: boolean;
   priority: number;
   createdAt: string;
@@ -234,6 +232,9 @@ export function toLiveAnnouncement(a: AdminSiteAnnouncement): LiveSiteAnnounceme
     delaySeconds: a.delaySeconds,
     dismissible: a.dismissible,
     requireMarketingConsent: a.requireMarketingConsent,
+    startsAt: a.startsAt,
+    endsAt: a.endsAt,
+    updatedAt: a.updatedAt,
   };
 }
 
@@ -255,17 +256,28 @@ export function validateAnnouncementForm(form: AnnouncementFormState): string | 
   if (form.endsAt < form.startsAt) {
     return "End date must be on or after the start date";
   }
+  if (
+    announcementUsesOverlay(form.type) &&
+    !form.dismissible &&
+    !form.ctaUrl.trim() &&
+    !form.discountCode.trim()
+  ) {
+    return "A non-closable popup requires a link or discount code";
+  }
   return null;
 }
 
 export async function fetchSiteAnnouncements(
   filters: AnnouncementListFilters,
+  page = 1,
   init?: RequestInit,
 ) {
   const params = new URLSearchParams();
   if (filters.status !== "all") params.set("status", filters.status);
   if (filters.type !== "all") params.set("type", filters.type);
   if (filters.search.trim()) params.set("search", filters.search.trim());
+  params.set("page", String(page));
+  params.set("limit", "20");
 
   const res = await authFetch(
     `${API_BASE}/api/admin/site-announcements?${params}`,
@@ -293,8 +305,16 @@ export async function fetchSiteAnnouncements(
         : "Failed to load announcements";
     throw new Error(msg);
   }
-  const announcements = (json as { data?: { announcements?: unknown } }).data?.announcements;
-  return (Array.isArray(announcements) ? announcements : []) as AdminSiteAnnouncement[];
+  const data = (json as {
+    data?: { announcements?: unknown; total?: unknown; page?: unknown; limit?: unknown };
+  }).data;
+  const announcements = data?.announcements;
+  return {
+    items: (Array.isArray(announcements) ? announcements : []) as AdminSiteAnnouncement[],
+    total: Math.max(0, Number(data?.total) || 0),
+    page: Math.max(1, Number(data?.page) || page),
+    limit: Math.max(1, Number(data?.limit) || 20),
+  };
 }
 
 export async function saveSiteAnnouncement(

--- a/lib/adminRbac.ts
+++ b/lib/adminRbac.ts
@@ -19,6 +19,7 @@ export type AdminPermission =
   | 'audit.read'
   | 'email_logs.read'
   | 'cms.manage'
+  | 'campaigns.manage'
   | 'discounts.manage'
   | 'loyalty.manage'
   | 'referrals.manage'
@@ -49,6 +50,7 @@ export const ADMIN_PAGE_PERMISSIONS: Array<{ prefix: string; permission: AdminPe
   { prefix: '/admin/kpi', permission: 'kpi.read' },
   { prefix: '/admin/audit-logs', permission: 'audit.read' },
   { prefix: '/admin/cms', permission: 'cms.manage' },
+  { prefix: '/admin/campaigns', permission: 'campaigns.manage' },
   { prefix: '/admin/discount-codes', permission: 'discounts.manage' },
   { prefix: '/admin/loyalty', permission: 'loyalty.manage' },
   { prefix: '/admin/professional-levels', permission: 'loyalty.manage' },
@@ -92,6 +94,7 @@ export const ADMIN_ROLE_ACCESS: Record<AdminRole, string[]> = {
   ],
   marketing: [
     'CMS',
+    'Email campaigns',
     'Discount codes',
     'Loyalty & points',
     'Referrals',

--- a/lib/cms.ts
+++ b/lib/cms.ts
@@ -70,7 +70,7 @@ export interface CmsUpsertPayload {
   body?: string;
   excerpt?: string;
   coverImage?: string;
-  coverImageAlt?: string;
+  coverImageAlt?: string | null;
   category?: string;
   tags?: string[];
   status?: CmsContentStatus;

--- a/lib/marketing/siteAnnouncements/dismissStorage.ts
+++ b/lib/marketing/siteAnnouncements/dismissStorage.ts
@@ -1,16 +1,21 @@
 import { DISMISS_STORAGE_PREFIX } from "./constants";
+import type { SiteAnnouncement } from "./types";
 
-export function isAnnouncementDismissed(id: string): boolean {
+function storageKey(announcement: SiteAnnouncement): string {
+  return `${DISMISS_STORAGE_PREFIX}${announcement._id}:${announcement.updatedAt}`;
+}
+
+export function isAnnouncementDismissed(announcement: SiteAnnouncement): boolean {
   try {
-    return localStorage.getItem(`${DISMISS_STORAGE_PREFIX}${id}`) === "1";
+    return localStorage.getItem(storageKey(announcement)) === "1";
   } catch {
     return false;
   }
 }
 
-export function dismissAnnouncement(id: string): void {
+export function dismissAnnouncement(announcement: SiteAnnouncement): void {
   try {
-    localStorage.setItem(`${DISMISS_STORAGE_PREFIX}${id}`, "1");
+    localStorage.setItem(storageKey(announcement), "1");
   } catch {
     // Private mode / blocked storage — session hide still works via React state.
   }

--- a/lib/marketing/siteAnnouncements/types.ts
+++ b/lib/marketing/siteAnnouncements/types.ts
@@ -14,4 +14,7 @@ export interface SiteAnnouncement {
   delaySeconds: number;
   dismissible: boolean;
   requireMarketingConsent: boolean;
+  startsAt: string;
+  endsAt: string;
+  updatedAt: string;
 }


### PR DESCRIPTION
## Summary
- Admin campaigns page for creating/scheduling Brevo marketing sends
- Dashboard card gated via `openAdmin('/admin/campaigns')` + `campaigns.manage`
- Public `/unsubscribe` page for marketing opt-out

## Test plan
- [ ] `npm run build` passes
- [ ] Admin with `campaigns.manage` can open `/admin/campaigns`
- [ ] Unsubscribe page loads and posts to public unsubscribe API
- [ ] Dashboard card uses RBAC `openAdmin` helper


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an admin **Email Campaigns** area with create/edit (templates, multilingual content), audience preview, scheduling/UTM & re-engagement options, delivery stats, send/refresh/delete, and subscriber sync.
  * Added an **Email preferences** unsubscribe flow that confirms via URL parameters with timeout/abort and retry.
  * Enabled **admin site announcements** pagination.

* **Permissions & UI Updates**
  * Made admin dashboard/navigation permission-driven; enforced support-chat and booking write gating.

* **Bug Fixes & Improvements**
  * Improved KPI export consistency, admin chat inbox pagination/error handling, and admin-invite post-auth validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->