### PR TITLE
Fix customer signup geocode contract and stale coordinates

### DIFF
--- a/app/(pages)/signup/customer/page.tsx
+++ b/app/(pages)/signup/customer/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useState, useEffect, Suspense } from 'react';
+import React, { useState, useEffect, useRef, Suspense } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -123,6 +123,8 @@ function CustomerSignupForm() {
   const [isAddressValid, setIsAddressValid] = useState(false);
   const [referralValid, setReferralValid] = useState<boolean | null>(null);
   const [referralReferrer, setReferralReferrer] = useState<string>('');
+  // Bumped whenever location fields change so in-flight geocode results are ignored
+  const geocodeRequestIdRef = useRef(0);
   const { signup } = useAuth();
   const router = useRouter();
   const searchParams = useSearchParams();
@@ -173,18 +175,36 @@ function CustomerSignupForm() {
     };
   }, [formData.referralCode]);
 
+  const LOCATION_FIELDS: Array<keyof FormData> = [
+    'address',
+    'city',
+    'postalCode',
+    'country',
+  ];
+
   const handleInputChange = (field: keyof FormData, value: string) => {
-    setFormData((prev) => ({
-      ...prev,
-      [field]: value,
-    }));
+    setFormData((prev) => {
+      const next: FormData = { ...prev, [field]: value };
+      if (LOCATION_FIELDS.includes(field)) {
+        geocodeRequestIdRef.current += 1;
+        next.latitude = undefined;
+        next.longitude = undefined;
+      }
+      return next;
+    });
   };
 
   // Handle address selection from autocomplete
   const handleAddressChange = (fullAddress: string, placeData?: PlaceData) => {
-    handleInputChange('address', fullAddress);
-
     if (!placeData?.coordinates) {
+      // Typing / clearing — drop any previously resolved coordinates
+      geocodeRequestIdRef.current += 1;
+      setFormData((prev) => ({
+        ...prev,
+        address: fullAddress,
+        latitude: undefined,
+        longitude: undefined,
+      }));
       return;
     }
 
@@ -202,8 +222,10 @@ function CustomerSignupForm() {
       component.types.includes('postal_code')
     );
 
+    geocodeRequestIdRef.current += 1;
     setFormData((prev) => ({
       ...prev,
+      address: fullAddress,
       city: cityComponent?.long_name || prev.city,
       country: countryComponent?.long_name || prev.country,
       postalCode: postalComponent?.long_name || prev.postalCode,
@@ -426,7 +448,8 @@ function CustomerSignupForm() {
       }
     }
 
-    // Prefer coords already captured from Places / blur geocode
+    // Prefer coords only when they still match the current location fields
+    // (edits to address/city/postal/country clear lat/lng above).
     if (
       typeof formData.latitude === 'number' &&
       typeof formData.longitude === 'number'
@@ -438,9 +461,15 @@ function CustomerSignupForm() {
     }
 
     setAddressValidating(true);
+    const requestId = ++geocodeRequestIdRef.current;
     const fullAddress = `${formData.address}, ${formData.city}, ${formData.postalCode}, ${formData.country}`;
     const coordinates = await geocodeAddress(fullAddress);
     setAddressValidating(false);
+
+    // Address changed while geocoding — discard stale result
+    if (requestId !== geocodeRequestIdRef.current) {
+      return false;
+    }
 
     if (!coordinates) {
       toast.error(

--- a/app/(pages)/signup/customer/page.tsx
+++ b/app/(pages)/signup/customer/page.tsx
@@ -182,11 +182,18 @@ function CustomerSignupForm() {
     'country',
   ];
 
+  const invalidateResolvedCoordinates = () => {
+    geocodeRequestIdRef.current += 1;
+  };
+
   const handleInputChange = (field: keyof FormData, value: string) => {
+    const clearsCoordinates = LOCATION_FIELDS.includes(field);
+    if (clearsCoordinates) {
+      invalidateResolvedCoordinates();
+    }
     setFormData((prev) => {
       const next: FormData = { ...prev, [field]: value };
-      if (LOCATION_FIELDS.includes(field)) {
-        geocodeRequestIdRef.current += 1;
+      if (clearsCoordinates) {
         next.latitude = undefined;
         next.longitude = undefined;
       }
@@ -198,7 +205,7 @@ function CustomerSignupForm() {
   const handleAddressChange = (fullAddress: string, placeData?: PlaceData) => {
     if (!placeData?.coordinates) {
       // Typing / clearing — drop any previously resolved coordinates
-      geocodeRequestIdRef.current += 1;
+      invalidateResolvedCoordinates();
       setFormData((prev) => ({
         ...prev,
         address: fullAddress,
@@ -222,7 +229,8 @@ function CustomerSignupForm() {
       component.types.includes('postal_code')
     );
 
-    geocodeRequestIdRef.current += 1;
+    // New resolved coords — invalidate any in-flight geocode for the prior address
+    invalidateResolvedCoordinates();
     setFormData((prev) => ({
       ...prev,
       address: fullAddress,
@@ -240,40 +248,55 @@ function CustomerSignupForm() {
       return;
     }
 
-    setFormData((prev) => {
-      let next = prev;
+    const parsed = vatValidation.parsedAddress;
+    const patch: Partial<FormData> = {};
+    let locationChanged = false;
 
-      const applyUpdate = (patch: Partial<FormData>) => {
-        if (next === prev) {
-          next = { ...prev, ...patch };
-        } else {
-          next = { ...next, ...patch };
-        }
-      };
+    if (!formData.companyName && vatValidation.companyName) {
+      patch.companyName = vatValidation.companyName;
+    }
 
-      if (!prev.companyName && vatValidation.companyName) {
-        applyUpdate({ companyName: vatValidation.companyName });
+    if (parsed) {
+      if (parsed.streetAddress && !formData.address) {
+        patch.address = parsed.streetAddress;
+        locationChanged = true;
       }
-
-      if (vatValidation.parsedAddress) {
-        const parsed = vatValidation.parsedAddress;
-        if (parsed.streetAddress && !prev.address) {
-          applyUpdate({ address: parsed.streetAddress });
-        }
-        if (parsed.city && !prev.city) {
-          applyUpdate({ city: parsed.city });
-        }
-        if (parsed.postalCode && !prev.postalCode) {
-          applyUpdate({ postalCode: parsed.postalCode });
-        }
-        if (parsed.country && !prev.country) {
-          applyUpdate({ country: parsed.country });
-        }
+      if (parsed.city && !formData.city) {
+        patch.city = parsed.city;
+        locationChanged = true;
       }
+      if (parsed.postalCode && !formData.postalCode) {
+        patch.postalCode = parsed.postalCode;
+        locationChanged = true;
+      }
+      if (parsed.country && !formData.country) {
+        patch.country = parsed.country;
+        locationChanged = true;
+      }
+    }
 
-      return next;
-    });
-  }, [vatValidation, formData.customerType]);
+    if (locationChanged) {
+      // VAT may fill city/postal/country after Places set coords without
+      // address_components — drop those coords so submit re-geocodes.
+      patch.latitude = undefined;
+      patch.longitude = undefined;
+      invalidateResolvedCoordinates();
+    }
+
+    if (Object.keys(patch).length === 0) {
+      return;
+    }
+
+    setFormData((prev) => ({ ...prev, ...patch }));
+  }, [
+    vatValidation,
+    formData.customerType,
+    formData.companyName,
+    formData.address,
+    formData.city,
+    formData.postalCode,
+    formData.country,
+  ]);
 
   const validateVatNumber = async () => {
     if (!formData.vatNumber.trim()) {

--- a/app/(pages)/signup/customer/page.tsx
+++ b/app/(pages)/signup/customer/page.tsx
@@ -71,6 +71,8 @@ interface FormData {
   // Coordinates (auto-populated from geocoding)
   latitude?: number;
   longitude?: number;
+  /** Normalized address|city|postal|country key coords were resolved for */
+  resolvedLocationKey?: string;
   // Referral
   referralCode: string;
 }
@@ -182,8 +184,34 @@ function CustomerSignupForm() {
     'country',
   ];
 
+  const normalizeLocationKey = ({
+    address,
+    city,
+    postalCode,
+    country,
+  }: {
+    address: string;
+    city: string;
+    postalCode: string;
+    country: string;
+  }) =>
+    [address, city, postalCode, country]
+      .map((part) => part.trim().toLowerCase())
+      .join('|');
+
+  const clearResolvedCoordinates = (
+    data: FormData
+  ): FormData => ({
+    ...data,
+    latitude: undefined,
+    longitude: undefined,
+    resolvedLocationKey: undefined,
+  });
+
   const invalidateResolvedCoordinates = () => {
     geocodeRequestIdRef.current += 1;
+    // Drop validating UI if an in-flight geocode was just invalidated
+    setAddressValidating(false);
   };
 
   const handleInputChange = (field: keyof FormData, value: string) => {
@@ -194,8 +222,7 @@ function CustomerSignupForm() {
     setFormData((prev) => {
       const next: FormData = { ...prev, [field]: value };
       if (clearsCoordinates) {
-        next.latitude = undefined;
-        next.longitude = undefined;
+        return clearResolvedCoordinates(next);
       }
       return next;
     });
@@ -206,12 +233,12 @@ function CustomerSignupForm() {
     if (!placeData?.coordinates) {
       // Typing / clearing — drop any previously resolved coordinates
       invalidateResolvedCoordinates();
-      setFormData((prev) => ({
-        ...prev,
-        address: fullAddress,
-        latitude: undefined,
-        longitude: undefined,
-      }));
+      setFormData((prev) =>
+        clearResolvedCoordinates({
+          ...prev,
+          address: fullAddress,
+        })
+      );
       return;
     }
 
@@ -231,15 +258,26 @@ function CustomerSignupForm() {
 
     // New resolved coords — invalidate any in-flight geocode for the prior address
     invalidateResolvedCoordinates();
-    setFormData((prev) => ({
-      ...prev,
-      address: fullAddress,
-      city: cityComponent?.long_name || prev.city,
-      country: countryComponent?.long_name || prev.country,
-      postalCode: postalComponent?.long_name || prev.postalCode,
-      latitude: coordinates.lat,
-      longitude: coordinates.lng,
-    }));
+    setFormData((prev) => {
+      const city = cityComponent?.long_name || prev.city;
+      const country = countryComponent?.long_name || prev.country;
+      const postalCode = postalComponent?.long_name || prev.postalCode;
+      return {
+        ...prev,
+        address: fullAddress,
+        city,
+        country,
+        postalCode,
+        latitude: coordinates.lat,
+        longitude: coordinates.lng,
+        resolvedLocationKey: normalizeLocationKey({
+          address: fullAddress,
+          city,
+          postalCode,
+          country,
+        }),
+      };
+    });
   };
 
   // Auto-populate business info from VAT validation
@@ -280,6 +318,7 @@ function CustomerSignupForm() {
       // address_components — drop those coords so submit re-geocodes.
       patch.latitude = undefined;
       patch.longitude = undefined;
+      patch.resolvedLocationKey = undefined;
       invalidateResolvedCoordinates();
     }
 
@@ -471,11 +510,12 @@ function CustomerSignupForm() {
       }
     }
 
-    // Prefer coords only when they still match the current location fields
-    // (edits to address/city/postal/country clear lat/lng above).
+    // Reuse coords only when they were resolved for this exact location key
+    const currentLocationKey = normalizeLocationKey(formData);
     if (
       typeof formData.latitude === 'number' &&
-      typeof formData.longitude === 'number'
+      typeof formData.longitude === 'number' &&
+      formData.resolvedLocationKey === currentLocationKey
     ) {
       return {
         latitude: formData.latitude,
@@ -487,12 +527,14 @@ function CustomerSignupForm() {
     const requestId = ++geocodeRequestIdRef.current;
     const fullAddress = `${formData.address}, ${formData.city}, ${formData.postalCode}, ${formData.country}`;
     const coordinates = await geocodeAddress(fullAddress);
-    setAddressValidating(false);
 
-    // Address changed while geocoding — discard stale result
+    // Address changed while geocoding — discard stale result. Do not clear
+    // addressValidating here: a newer request may own it, or invalidate already did.
     if (requestId !== geocodeRequestIdRef.current) {
       return false;
     }
+
+    setAddressValidating(false);
 
     if (!coordinates) {
       toast.error(
@@ -505,6 +547,7 @@ function CustomerSignupForm() {
       ...prev,
       latitude: coordinates.lat,
       longitude: coordinates.lng,
+      resolvedLocationKey: currentLocationKey,
     }));
 
     // Return coords directly — setFormData is async and must not be read stale on submit

--- a/app/(pages)/signup/customer/page.tsx
+++ b/app/(pages)/signup/customer/page.tsx
@@ -184,40 +184,32 @@ function CustomerSignupForm() {
   const handleAddressChange = (fullAddress: string, placeData?: PlaceData) => {
     handleInputChange('address', fullAddress);
 
-    // If we have place data from autocomplete dropdown, use it directly
-    if (placeData?.coordinates && placeData?.address_components) {
-      console.log(
-        'Using place data from autocomplete - no API call needed'
-      );
-
-      const components = placeData.address_components;
-      const cityComponent = components.find(
-        (component) =>
-          component.types.includes('locality') ||
-          component.types.includes('administrative_area_level_2')
-      );
-      const countryComponent = components.find((component) =>
-        component.types.includes('country')
-      );
-      const postalComponent = components.find((component) =>
-        component.types.includes('postal_code')
-      );
-
-      const city = cityComponent?.long_name || '';
-      const country = countryComponent?.long_name || '';
-      const postalCode = postalComponent?.long_name || '';
-
-      const coordinates = placeData.coordinates;
-
-      setFormData((prev) => ({
-        ...prev,
-        city: city || prev.city,
-        country: country || prev.country,
-        postalCode: postalCode || prev.postalCode,
-        latitude: coordinates.lat,
-        longitude: coordinates.lng,
-      }));
+    if (!placeData?.coordinates) {
+      return;
     }
+
+    const coordinates = placeData.coordinates;
+    const components = placeData.address_components;
+    const cityComponent = components?.find(
+      (component) =>
+        component.types.includes('locality') ||
+        component.types.includes('administrative_area_level_2')
+    );
+    const countryComponent = components?.find((component) =>
+      component.types.includes('country')
+    );
+    const postalComponent = components?.find((component) =>
+      component.types.includes('postal_code')
+    );
+
+    setFormData((prev) => ({
+      ...prev,
+      city: cityComponent?.long_name || prev.city,
+      country: countryComponent?.long_name || prev.country,
+      postalCode: postalComponent?.long_name || prev.postalCode,
+      latitude: coordinates.lat,
+      longitude: coordinates.lng,
+    }));
   };
 
   // Auto-populate business info from VAT validation
@@ -337,11 +329,18 @@ function CustomerSignupForm() {
 
       const data = await response.json();
 
-      if (data.success && data.isValid && data.coordinates) {
-        return {
-          lat: data.coordinates.lat,
-          lng: data.coordinates.lng,
-        };
+      if (!data.success || !data.isValid) {
+        return null;
+      }
+
+      // Prefer explicit coordinates; fall back to Google result geometry
+      const lat =
+        data.coordinates?.lat ?? data.data?.geometry?.location?.lat;
+      const lng =
+        data.coordinates?.lng ?? data.data?.geometry?.location?.lng;
+
+      if (typeof lat === 'number' && typeof lng === 'number') {
+        return { lat, lng };
       }
       return null;
     } catch (error) {
@@ -350,7 +349,9 @@ function CustomerSignupForm() {
     }
   };
 
-  const validateForm = async (): Promise<boolean> => {
+  const validateForm = async (): Promise<
+    { latitude: number; longitude: number } | false
+  > => {
     // Basic validations
     if (!formData.name.trim()) {
       toast.error('Please enter your full name');
@@ -425,36 +426,47 @@ function CustomerSignupForm() {
       }
     }
 
-    // Check if we already have coordinates (from autocomplete selection)
-    // If not, geocode the address
-    if (!formData.latitude || !formData.longitude) {
-      setAddressValidating(true);
-      const fullAddress = `${formData.address}, ${formData.city}, ${formData.postalCode}, ${formData.country}`;
-      const coordinates = await geocodeAddress(fullAddress);
-      setAddressValidating(false);
-
-      if (!coordinates) {
-        toast.error(
-          'Unable to validate your address. Please check and try again.'
-        );
-        return false;
-      }
-
-      // Store coordinates in formData
-      setFormData((prev) => ({
-        ...prev,
-        latitude: coordinates.lat,
-        longitude: coordinates.lng,
-      }));
+    // Prefer coords already captured from Places / blur geocode
+    if (
+      typeof formData.latitude === 'number' &&
+      typeof formData.longitude === 'number'
+    ) {
+      return {
+        latitude: formData.latitude,
+        longitude: formData.longitude,
+      };
     }
 
-    return true;
+    setAddressValidating(true);
+    const fullAddress = `${formData.address}, ${formData.city}, ${formData.postalCode}, ${formData.country}`;
+    const coordinates = await geocodeAddress(fullAddress);
+    setAddressValidating(false);
+
+    if (!coordinates) {
+      toast.error(
+        'Unable to validate your address. Please check and try again.'
+      );
+      return false;
+    }
+
+    setFormData((prev) => ({
+      ...prev,
+      latitude: coordinates.lat,
+      longitude: coordinates.lng,
+    }));
+
+    // Return coords directly — setFormData is async and must not be read stale on submit
+    return {
+      latitude: coordinates.lat,
+      longitude: coordinates.lng,
+    };
   };
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
 
-    if (!(await validateForm())) return;
+    const validatedLocation = await validateForm();
+    if (!validatedLocation) return;
 
     setLoading(true);
     try {
@@ -471,8 +483,8 @@ function CustomerSignupForm() {
         city: formData.city.trim(),
         country: formData.country.trim(),
         postalCode: formData.postalCode.trim(),
-        latitude: formData.latitude,
-        longitude: formData.longitude,
+        latitude: validatedLocation.latitude,
+        longitude: validatedLocation.longitude,
         // Business fields (only if business type)
         ...(formData.customerType === 'business' && {
           companyName: formData.companyName.trim(),


### PR DESCRIPTION
## Summary
- Accept `data.coordinates` from validate-address, with fallback to Google geometry location.
- Store lat/lng whenever coordinates exist (not only when address_components are present).
- Return resolved coords from `validateForm` and use them in `handleSubmit` to avoid stale `setFormData` on signup.

## Test plan
- [ ] `npm run build` passes
- [ ] Customer signup with Places autocomplete stores and submits coordinates
- [ ] Customer signup with typed/blur-validated address geocodes and submits lat/lng
- [ ] Account creation succeeds for a verified address (no missing latitude/longitude)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved address autocomplete reliability when location data is incomplete.
  * Preserved existing address details while updating available location information.
  * Enhanced geocoding validation and coordinate handling during signup.
  * Prevented outdated location results from overwriting newer address edits.
  * Ensured signup submissions use coordinates matching the current address.
  * Cleared stale coordinates when address details change.
  * Filled VAT-derived address fields only when blank.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->